### PR TITLE
Refactor `Article` and `Experiment` repositories to clean up their inserts

### DIFF
--- a/src/poprox_storage/concepts/experiment.py
+++ b/src/poprox_storage/concepts/experiment.py
@@ -1,18 +1,17 @@
 from __future__ import annotations
 
 from datetime import date, timedelta
-from typing import List, Optional
 from uuid import UUID
 
 from pydantic import BaseModel, PositiveInt
 
 
 class Experiment(BaseModel):
-    experiment_id: Optional[UUID] = None
+    experiment_id: UUID | None = None
     description: str
     start_date: date
     end_date: date
-    phases: List[Phase]
+    phases: list[Phase]
 
     @property
     def recommenders(self):
@@ -61,23 +60,23 @@ class Treatment(BaseModel):
 
 
 class Group(BaseModel):
-    group_id: Optional[UUID] = None
+    group_id: UUID | None = None
     name: str
     minimum_size: PositiveInt
 
 
 class Recommender(BaseModel):
-    recommender_id: Optional[UUID] = None
+    recommender_id: UUID | None = None
     name: str
     endpoint_url: str
 
 
 class Phase(BaseModel):
-    phase_id: Optional[UUID] = None
+    phase_id: UUID | None = None
     name: str
     start_date: date
     end_date: date
-    treatments: List[Treatment]
+    treatments: list[Treatment]
 
     @property
     def duration(self) -> timedelta:
@@ -85,6 +84,6 @@ class Phase(BaseModel):
 
 
 class Allocation(BaseModel):
-    allocation_id: UUID
+    allocation_id: UUID | None = None
     account_id: UUID
     group_id: UUID

--- a/src/poprox_storage/repositories/articles.py
+++ b/src/poprox_storage/repositories/articles.py
@@ -139,48 +139,14 @@ class DbArticleRepository(DatabaseRepository):
 
         return failed
 
-    def insert_article(self, article: Article) -> Optional[UUID]:
-        article_table = self.tables["articles"]
-        return self._upsert_and_return_id(
-            self.conn,
-            article_table,
-            {
-                "title": article.title,
-                "content": article.content,
-                "url": article.url,
-                "published_at": article.published_at,
-            },
-            constraint="uq_articles",
-        )
+    def insert_article(self, article: Article) -> UUID | None:
+        return self._insert_model("articles", article)
 
-    def insert_entity(self, entity: Entity) -> Optional[UUID]:
-        entity_table = self.tables["entities"]
-        return self._upsert_and_return_id(
-            self.conn,
-            entity_table,
-            {
-                "name": entity.name,
-                "entity_type": entity.entity_type,
-                "source": entity.source,
-                "external_id": entity.external_id,
-                "raw_data": entity.raw_data,
-            },
-            constraint="uq_entities",
-        )
+    def insert_entity(self, entity: Entity) -> UUID | None:
+        return self._insert_model("entities", entity)
 
-    def insert_mention(self, mention: Mention) -> Optional[UUID]:
-        mention_table = self.tables["mentions"]
-        return self._upsert_and_return_id(
-            self.conn,
-            mention_table,
-            {
-                "article_id": mention.article_id,
-                "entity_id": mention.entity.entity_id,
-                "source": mention.source,
-                "relevance": mention.relevance,
-            },
-            constraint="uq_mentions",
-        )
+    def insert_mention(self, mention: Mention) -> UUID | None:
+        return self._insert_model("mentions", mention, exclude={"entity"})
 
     def _get_articles(self, article_table, where_clause=None) -> List[Article]:
         query = article_table.select()

--- a/src/poprox_storage/repositories/articles.py
+++ b/src/poprox_storage/repositories/articles.py
@@ -140,13 +140,13 @@ class DbArticleRepository(DatabaseRepository):
         return failed
 
     def insert_article(self, article: Article) -> UUID | None:
-        return self._insert_model("articles", article)
+        return self._insert_model("articles", article, constraint="uq_articles")
 
     def insert_entity(self, entity: Entity) -> UUID | None:
-        return self._insert_model("entities", entity)
+        return self._insert_model("entities", entity, constraint="uq_entities")
 
     def insert_mention(self, mention: Mention) -> UUID | None:
-        return self._insert_model("mentions", mention, exclude={"entity"})
+        return self._insert_model("mentions", mention, exclude={"entity"}, constraint="uq_mentions")
 
     def _get_articles(self, article_table, where_clause=None) -> List[Article]:
         query = article_table.select()

--- a/src/poprox_storage/repositories/data_stores/db.py
+++ b/src/poprox_storage/repositories/data_stores/db.py
@@ -32,6 +32,17 @@ class DatabaseRepository:
         result = self.conn.execute(query).fetchall()
         return [row[0] for row in result]
 
+    def _insert_model(self, table_name: str, model, *, constraint_name: str | None = None, exclude=None):
+        if not constraint_name:
+            constraint_name = "uq_" + table_name
+
+        return self._upsert_and_return_id(
+            self.conn,
+            self.tables[table_name],
+            model.model_dump(exclude=exclude),
+            constraint=constraint_name,
+        )
+
     def _upsert_and_return_id(
         self,
         conn,

--- a/src/poprox_storage/repositories/data_stores/db.py
+++ b/src/poprox_storage/repositories/data_stores/db.py
@@ -32,15 +32,30 @@ class DatabaseRepository:
         result = self.conn.execute(query).fetchall()
         return [row[0] for row in result]
 
-    def _insert_model(self, table_name: str, model, *, constraint_name: str | None = None, exclude=None):
+    def _insert_model(
+        self,
+        table_name: str,
+        model,
+        addl_fields: dict[str, Any] | None = None,
+        *,
+        constraint_name: str | None = None,
+        exclude=None,
+        commit: bool = True,
+    ):
         if not constraint_name:
             constraint_name = "uq_" + table_name
+
+        fields: dict[str, Any] = model.model_dump(exclude=exclude)
+
+        if addl_fields:
+            fields.update(addl_fields)
 
         return self._upsert_and_return_id(
             self.conn,
             self.tables[table_name],
-            model.model_dump(exclude=exclude),
+            fields,
             constraint=constraint_name,
+            commit=commit,
         )
 
     def _upsert_and_return_id(

--- a/src/poprox_storage/repositories/data_stores/db.py
+++ b/src/poprox_storage/repositories/data_stores/db.py
@@ -38,13 +38,10 @@ class DatabaseRepository:
         model,
         addl_fields: dict[str, Any] | None = None,
         *,
-        constraint_name: str | None = None,
+        constraint: str | None = None,
         exclude=None,
         commit: bool = True,
     ):
-        if not constraint_name:
-            constraint_name = "uq_" + table_name
-
         fields: dict[str, Any] = model.model_dump(exclude=exclude)
 
         if addl_fields:
@@ -54,7 +51,7 @@ class DatabaseRepository:
             self.conn,
             self.tables[table_name],
             fields,
-            constraint=constraint_name,
+            constraint=constraint,
             commit=commit,
         )
 

--- a/src/poprox_storage/repositories/experiments.py
+++ b/src/poprox_storage/repositories/experiments.py
@@ -33,23 +33,23 @@ class DbExperimentRepository(DatabaseRepository):
         assignments = assignments or {}
         self.conn.rollback()
         with self.conn.begin():
-            experiment_id = self.insert_experiment(experiment)
+            experiment_id = self._insert_experiment(experiment)
 
             for group in experiment.groups:
-                group.group_id = self.insert_expt_group(experiment_id, group)
+                group.group_id = self._insert_expt_group(experiment_id, group)
                 for account in assignments.get(group.name, []):
-                    self.insert_expt_assignment(account.account_id, group)
+                    self._insert_expt_assignment(account.account_id, group)
 
             for recommender in experiment.recommenders:
-                recommender.recommender_id = self.insert_expt_recommender(
+                recommender.recommender_id = self._insert_expt_recommender(
                     experiment_id,
                     recommender,
                 )
 
             for phase in experiment.phases:
-                phase.phase_id = self.insert_expt_phase(experiment_id, phase)
+                phase.phase_id = self._insert_expt_phase(experiment_id, phase)
                 for treatment in phase.treatments:
-                    self.insert_expt_treatment(phase.phase_id, treatment)
+                    self._insert_expt_treatment(phase.phase_id, treatment)
 
         return experiment_id
 
@@ -116,10 +116,10 @@ class DbExperimentRepository(DatabaseRepository):
 
         return group_lookup_by_account
 
-    def insert_experiment(self, experiment: Experiment) -> UUID | None:
+    def _insert_experiment(self, experiment: Experiment) -> UUID | None:
         return self._insert_model("experiments", experiment, exclude={"phases"}, commit=False)
 
-    def insert_expt_group(
+    def _insert_expt_group(
         self,
         experiment_id: UUID,
         group: Group,
@@ -128,7 +128,7 @@ class DbExperimentRepository(DatabaseRepository):
             "expt_groups", group, {"experiment_id": experiment_id}, exclude={"minimum_size"}, commit=False
         )
 
-    def insert_expt_recommender(
+    def _insert_expt_recommender(
         self,
         experiment_id: UUID,
         recommender: Recommender,
@@ -144,7 +144,7 @@ class DbExperimentRepository(DatabaseRepository):
             commit=False,
         )
 
-    def insert_expt_phase(
+    def _insert_expt_phase(
         self,
         experiment_id: UUID,
         phase: Phase,
@@ -157,7 +157,7 @@ class DbExperimentRepository(DatabaseRepository):
             commit=False,
         )
 
-    def insert_expt_treatment(
+    def _insert_expt_treatment(
         self,
         phase_id: UUID,
         treatment: Treatment,
@@ -174,7 +174,7 @@ class DbExperimentRepository(DatabaseRepository):
             commit=False,
         )
 
-    def insert_expt_assignment(
+    def _insert_expt_assignment(
         self,
         account_id: UUID,
         group: Group,

--- a/src/poprox_storage/repositories/experiments.py
+++ b/src/poprox_storage/repositories/experiments.py
@@ -1,11 +1,10 @@
 import datetime
 from uuid import UUID
-from typing import Dict, List, Optional
 
 import tomli
-from sqlalchemy import Connection, Table, select, and_
-
 from poprox_concepts import Account
+from sqlalchemy import Connection, Table, and_, select
+
 from poprox_storage.concepts.experiment import (
     Experiment,
     Group,
@@ -24,7 +23,7 @@ from poprox_storage.repositories.data_stores.s3 import S3Repository
 class DbExperimentRepository(DatabaseRepository):
     def __init__(self, connection: Connection):
         super().__init__(connection)
-        self.tables: Dict[str, Table] = self._load_tables(
+        self.tables: dict[str, Table] = self._load_tables(
             "experiments",
             "expt_allocations",
             "expt_groups",
@@ -33,25 +32,21 @@ class DbExperimentRepository(DatabaseRepository):
             "expt_treatments",
         )
 
-    def store_experiment(
-        self, experiment: Experiment, assignments: Dict[str, List[Account]] = None
-    ):
+    def store_experiment(self, experiment: Experiment, assignments: dict[str, list[Account]] | None = None):
         assignments = assignments or {}
         self.conn.rollback()
         with self.conn.begin():
-            experiment_id = insert_experiment(
-                self.conn, self.tables["experiments"], experiment
-            )
+            experiment_id = self.insert_experiment(self.conn, self.tables["experiments"], experiment)
 
             for group in experiment.groups:
-                group.group_id = insert_expt_group(
+                group.group_id = self.insert_expt_group(
                     self.conn,
                     self.tables["expt_groups"],
                     experiment_id,
                     group,
                 )
                 for account in assignments.get(group.name, []):
-                    insert_expt_assignment(
+                    self.insert_expt_assignment(
                         self.conn,
                         self.tables["expt_allocations"],
                         account.account_id,
@@ -59,7 +54,7 @@ class DbExperimentRepository(DatabaseRepository):
                     )
 
             for recommender in experiment.recommenders:
-                recommender.recommender_id = insert_expt_recommender(
+                recommender.recommender_id = self.insert_expt_recommender(
                     self.conn,
                     self.tables["expt_recommenders"],
                     experiment_id,
@@ -67,14 +62,14 @@ class DbExperimentRepository(DatabaseRepository):
                 )
 
             for phase in experiment.phases:
-                phase.phase_id = insert_expt_phase(
+                phase.phase_id = self.insert_expt_phase(
                     self.conn,
                     self.tables["expt_phases"],
                     experiment_id,
                     phase,
                 )
                 for treatment in phase.treatments:
-                    insert_expt_treatment(
+                    self.insert_expt_treatment(
                         self.conn,
                         self.tables["expt_treatments"],
                         phase.phase_id,
@@ -83,9 +78,7 @@ class DbExperimentRepository(DatabaseRepository):
 
         return experiment_id
 
-    def get_active_expt_group_ids(
-        self, date: Optional[datetime.date] = None
-    ) -> List[UUID]:
+    def get_active_expt_group_ids(self, date: datetime.date | None = None) -> list[UUID]:
         groups_tbl = self.tables["expt_groups"]
         phases_tbl = self.tables["expt_phases"]
         treatments_tbl = self.tables["expt_treatments"]
@@ -105,9 +98,7 @@ class DbExperimentRepository(DatabaseRepository):
 
         return self._id_query(groups_query)
 
-    def get_active_expt_endpoint_urls(
-        self, date: Optional[datetime.date] = None
-    ) -> Dict[UUID, str]:
+    def get_active_expt_endpoint_urls(self, date: datetime.date | None = None) -> dict[UUID, str]:
         groups_tbl = self.tables["expt_groups"]
         phases_tbl = self.tables["expt_phases"]
         recommenders_tbl = self.tables["expt_recommenders"]
@@ -136,21 +127,125 @@ class DbExperimentRepository(DatabaseRepository):
 
         return recommender_lookup_by_group
 
-    def get_active_expt_assignments(
-        self, date: Optional[datetime.date] = None
-    ) -> Dict[UUID, UUID]:
+    def get_active_expt_assignments(self, date: datetime.date | None = None) -> dict[UUID, UUID]:
         allocations_tbl = self.tables["expt_allocations"]
 
         group_ids = self.get_active_expt_group_ids(date)
 
         # Find accounts allocated to the groups that are assigned the active recommenders above
-        group_query = select(
-            allocations_tbl.c.account_id, allocations_tbl.c.group_id
-        ).where(allocations_tbl.c.group_id.in_(group_ids))
+        group_query = select(allocations_tbl.c.account_id, allocations_tbl.c.group_id).where(
+            allocations_tbl.c.group_id.in_(group_ids)
+        )
         result = self.conn.execute(group_query).fetchall()
         group_lookup_by_account = {row[0]: row[1] for row in result}
 
         return group_lookup_by_account
+
+    def insert_experiment(
+        self,
+        conn: Connection,
+        experiments_table: Table,
+        experiment: Experiment,
+    ) -> UUID | None:
+        return upsert_and_return_id(
+            conn,
+            experiments_table,
+            {
+                "description": experiment.description,
+                "start_date": experiment.start_date,
+                "end_date": experiment.end_date,
+            },
+            commit=False,
+        )
+
+    def insert_expt_group(
+        self,
+        conn: Connection,
+        expt_groups_table: Table,
+        experiment_id: UUID,
+        group: Group,
+    ) -> UUID | None:
+        return upsert_and_return_id(
+            conn,
+            expt_groups_table,
+            {
+                "experiment_id": experiment_id,
+                "group_name": group.name,
+            },
+            commit=False,
+        )
+
+    def insert_expt_recommender(
+        self,
+        conn: Connection,
+        expt_recommenders_table: Table,
+        experiment_id: UUID,
+        recommender: Recommender,
+    ) -> UUID | None:
+        return upsert_and_return_id(
+            conn,
+            expt_recommenders_table,
+            {
+                "experiment_id": experiment_id,
+                "recommender_name": recommender.name,
+                "endpoint_url": recommender.endpoint_url,
+            },
+            commit=False,
+        )
+
+    def insert_expt_phase(
+        self,
+        conn: Connection,
+        expt_phases_table: Table,
+        experiment_id: UUID,
+        phase: Phase,
+    ) -> UUID | None:
+        return upsert_and_return_id(
+            conn,
+            expt_phases_table,
+            {
+                "experiment_id": experiment_id,
+                "phase_name": phase.name,
+                "start_date": phase.start_date,
+                "end_date": phase.end_date,
+            },
+            commit=False,
+        )
+
+    def insert_expt_treatment(
+        self,
+        conn: Connection,
+        expt_treatments_table: Table,
+        phase_id: UUID,
+        treatment: Treatment,
+    ) -> UUID | None:
+        return upsert_and_return_id(
+            conn,
+            expt_treatments_table,
+            {
+                "phase_id": phase_id,
+                "group_id": treatment.group.group_id,
+                "recommender_id": treatment.recommender.recommender_id,
+            },
+            commit=False,
+        )
+
+    def insert_expt_assignment(
+        self,
+        conn: Connection,
+        expt_allocations_table: Table,
+        account_id: UUID,
+        group_id: UUID,
+    ) -> UUID | None:
+        return upsert_and_return_id(
+            conn,
+            expt_allocations_table,
+            {
+                "account_id": account_id,
+                "group_id": group_id,
+            },
+            commit=False,
+        )
 
 
 class S3ExperimentRepository(S3Repository):
@@ -166,109 +261,3 @@ class S3ExperimentRepository(S3Repository):
         manifest_dict["phases"] = phases
 
         return ManifestFile.model_validate(manifest_dict)
-
-
-def insert_experiment(
-    conn: Connection,
-    experiments_table: Table,
-    experiment: Experiment,
-) -> Optional[UUID]:
-    return upsert_and_return_id(
-        conn,
-        experiments_table,
-        {
-            "description": experiment.description,
-            "start_date": experiment.start_date,
-            "end_date": experiment.end_date,
-        },
-        commit=False,
-    )
-
-
-def insert_expt_group(
-    conn: Connection,
-    expt_groups_table: Table,
-    experiment_id: UUID,
-    group: Group,
-) -> Optional[UUID]:
-    return upsert_and_return_id(
-        conn,
-        expt_groups_table,
-        {
-            "experiment_id": experiment_id,
-            "group_name": group.name,
-        },
-        commit=False,
-    )
-
-
-def insert_expt_recommender(
-    conn: Connection,
-    expt_recommenders_table: Table,
-    experiment_id: UUID,
-    recommender: Recommender,
-):
-    return upsert_and_return_id(
-        conn,
-        expt_recommenders_table,
-        {
-            "experiment_id": experiment_id,
-            "recommender_name": recommender.name,
-            "endpoint_url": recommender.endpoint_url,
-        },
-        commit=False,
-    )
-
-
-def insert_expt_phase(
-    conn: Connection,
-    expt_phases_table: Table,
-    experiment_id: UUID,
-    phase: Phase,
-):
-    return upsert_and_return_id(
-        conn,
-        expt_phases_table,
-        {
-            "experiment_id": experiment_id,
-            "phase_name": phase.name,
-            "start_date": phase.start_date,
-            "end_date": phase.end_date,
-        },
-        commit=False,
-    )
-
-
-def insert_expt_treatment(
-    conn: Connection,
-    expt_treatments_table: Table,
-    phase_id: UUID,
-    treatment: Treatment,
-):
-    return upsert_and_return_id(
-        conn,
-        expt_treatments_table,
-        {
-            "phase_id": phase_id,
-            "group_id": treatment.group.group_id,
-            "recommender_id": treatment.recommender.recommender_id,
-        },
-        commit=False,
-    )
-
-
-def insert_expt_assignment(
-    conn: Connection,
-    expt_allocations_table: Table,
-    account_id: UUID,
-    group_id: UUID,
-):
-    return upsert_and_return_id(
-        conn,
-        expt_allocations_table,
-        {
-            "account_id": account_id,
-            "group_id": group_id,
-        },
-        commit=False,
-    )

--- a/src/poprox_storage/repositories/experiments.py
+++ b/src/poprox_storage/repositories/experiments.py
@@ -13,10 +13,7 @@ from poprox_storage.concepts.experiment import (
     Treatment,
 )
 from poprox_storage.concepts.manifest import ManifestFile
-from poprox_storage.repositories.data_stores.db import (
-    DatabaseRepository,
-    upsert_and_return_id,
-)
+from poprox_storage.repositories.data_stores.db import DatabaseRepository
 from poprox_storage.repositories.data_stores.s3 import S3Repository
 
 
@@ -147,7 +144,7 @@ class DbExperimentRepository(DatabaseRepository):
         experiments_table: Table,
         experiment: Experiment,
     ) -> UUID | None:
-        return upsert_and_return_id(
+        return self._upsert_and_return_id(
             conn,
             experiments_table,
             {
@@ -165,7 +162,7 @@ class DbExperimentRepository(DatabaseRepository):
         experiment_id: UUID,
         group: Group,
     ) -> UUID | None:
-        return upsert_and_return_id(
+        return self._upsert_and_return_id(
             conn,
             expt_groups_table,
             {
@@ -182,7 +179,7 @@ class DbExperimentRepository(DatabaseRepository):
         experiment_id: UUID,
         recommender: Recommender,
     ) -> UUID | None:
-        return upsert_and_return_id(
+        return self._upsert_and_return_id(
             conn,
             expt_recommenders_table,
             {
@@ -200,7 +197,7 @@ class DbExperimentRepository(DatabaseRepository):
         experiment_id: UUID,
         phase: Phase,
     ) -> UUID | None:
-        return upsert_and_return_id(
+        return self._upsert_and_return_id(
             conn,
             expt_phases_table,
             {
@@ -219,7 +216,7 @@ class DbExperimentRepository(DatabaseRepository):
         phase_id: UUID,
         treatment: Treatment,
     ) -> UUID | None:
-        return upsert_and_return_id(
+        return self._upsert_and_return_id(
             conn,
             expt_treatments_table,
             {
@@ -237,7 +234,7 @@ class DbExperimentRepository(DatabaseRepository):
         account_id: UUID,
         group_id: UUID,
     ) -> UUID | None:
-        return upsert_and_return_id(
+        return self._upsert_and_return_id(
             conn,
             expt_allocations_table,
             {

--- a/src/poprox_storage/repositories/experiments.py
+++ b/src/poprox_storage/repositories/experiments.py
@@ -39,7 +39,8 @@ class DbExperimentRepository(DatabaseRepository):
             for group in experiment.groups:
                 group.group_id = self._insert_expt_group(experiment_id, group)
                 for account in assignments.get(group.name, []):
-                    self._insert_expt_assignment(account.account_id, group)
+                    allocation = Allocation(account_id=account.account_id, group_id=group.group_id)
+                    self._insert_expt_allocation(allocation)
 
             for recommender in experiment.recommenders:
                 recommender.recommender_id = self._insert_expt_recommender(
@@ -180,16 +181,13 @@ class DbExperimentRepository(DatabaseRepository):
             commit=False,
         )
 
-    def _insert_expt_assignment(
+    def _insert_expt_allocation(
         self,
-        account_id: UUID,
-        group: Group,
+        allocation: Allocation,
     ) -> UUID | None:
         return self._insert_model(
             "expt_allocations",
-            group,
-            {"account_id": account_id},
-            exclude={"name", "minimum_size"},
+            allocation,
             commit=False,
         )
 


### PR DESCRIPTION
Aside from style changes to appease the linter, this does a few things:
* Simplifies the process of inserting Pydantic models into the database in `Repository` classes
* Cleans up uses of the `upsert_and_return_id` function, which should be calls to the `_upsert_and_return_id` method
* Moves single-use code that inserts experiment stuff into the database from standalone public functions to private methods
