### PR TITLE
Add `source`, `external_id`, and `raw_data` fields to `Articles` during ingest

### DIFF
--- a/src/poprox_storage/repositories/articles.py
+++ b/src/poprox_storage/repositories/articles.py
@@ -184,9 +184,10 @@ class S3ArticleRepository(S3Repository):
         """
         response = self.s3_client.list_objects_v2(Bucket=DEV_BUCKET_NAME, Prefix=prefix)
 
-        files = sorted(
-            response.get("Contents", []), key=lambda d: d["LastModified"], reverse=True
-        )
+        files = sorted(response.get("Contents", []), key=lambda d: d["LastModified"], reverse=True)
+
+        if days_back:
+            files = files[-days_back:]
 
         return [f["Key"] for f in files]
 

--- a/src/poprox_storage/repositories/articles.py
+++ b/src/poprox_storage/repositories/articles.py
@@ -187,7 +187,7 @@ class S3ArticleRepository(S3Repository):
         files = sorted(response.get("Contents", []), key=lambda d: d["LastModified"], reverse=True)
 
         if days_back:
-            files = files[-days_back:]
+            files = files[:days_back]
 
         return [f["Key"] for f in files]
 

--- a/src/poprox_storage/repositories/articles.py
+++ b/src/poprox_storage/repositories/articles.py
@@ -112,7 +112,7 @@ class DbArticleRepository(DatabaseRepository):
         else:
             return None
 
-    def insert_articles(self, articles: list[Article], *, progress=False):
+    def insert_articles(self, articles: list[Article], *, mentions=False, progress=False):
         failed = 0
 
         if progress:
@@ -124,11 +124,12 @@ class DbArticleRepository(DatabaseRepository):
                 if article_id is None:
                     msg = f"Article insert failed for article {article}"
                     raise RuntimeError(msg)
-                for mention in article.mentions:
-                    entity_id = self.insert_entity(mention.entity)
-                    mention.article_id = article_id
-                    mention.entity.entity_id = entity_id
-                    mention.mention_id = self.insert_mention(mention)
+                if mentions:
+                    for mention in article.mentions:
+                        entity_id = self.insert_entity(mention.entity)
+                        mention.article_id = article_id
+                        mention.entity.entity_id = entity_id
+                        mention.mention_id = self.insert_mention(mention)
             except RuntimeError as exc:
                 logger.error(exc)
                 failed += 1

--- a/src/poprox_storage/repositories/articles.py
+++ b/src/poprox_storage/repositories/articles.py
@@ -136,13 +136,13 @@ class DbArticleRepository(DatabaseRepository):
         return failed
 
     def insert_article(self, article: Article) -> UUID | None:
-        return self._insert_model("articles", article, constraint="uq_articles")
+        return self._insert_model("articles", article, exclude={"article_id", "mentions"}, constraint="uq_articles")
 
     def insert_entity(self, entity: Entity) -> UUID | None:
-        return self._insert_model("entities", entity, constraint="uq_entities")
+        return self._insert_model("entities", entity, exclude={"entity_id"}, constraint="uq_entities")
 
     def insert_mention(self, mention: Mention) -> UUID | None:
-        return self._insert_model("mentions", mention, exclude={"entity"}, constraint="uq_mentions")
+        return self._insert_model("mentions", mention, exclude={"mention_id", "entity"}, constraint="uq_mentions")
 
     def _get_articles(self, article_table, where_clause=None) -> list[Article]:
         query = article_table.select()


### PR DESCRIPTION
This sets us up to use elements from `raw_data` to get the URIs we need to make requests for picture metadata (from the associations) and article text (from the NITF renditions.)

Depends on #10. The PR is targeted at the branch for #10 to make it easier to review by excluding commits that are in both, but should get merged into `main` after #10 goes in.