### PR TITLE
Move database migrations and dev database setup from `poprox-platform`

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,16 @@
 **Table of Contents**
 
 - [Installation](#installation)
-- [License](#license)
+
 
 ## Installation
 
 ```console
 pip install poprox-storage
+```
+
+### Dev Dependencies
+
+```console
+pip install .[dev]
 ```

--- a/dev/compose.yaml
+++ b/dev/compose.yaml
@@ -1,0 +1,34 @@
+# Comments are provided throughout this file to help you get started.
+# If you need more help, visit the Docker compose reference guide at
+# https://docs.docker.com/go/compose-spec-reference/
+
+# The `db-data` volume persists the database data between container
+# restarts. The `db-password` secret is used to set the database
+# password. You must create `db/password.txt` and add a password of
+# your choosing to it before running `docker compose up`.
+services:
+  db:
+    restart: always
+    image: postgres
+    user: postgres
+    secrets:
+      - db-password
+    environment:
+      - POSTGRES_DB=poprox
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD_FILE=/run/secrets/db-password
+    ports:
+        - "127.0.0.1:5433:5432"
+
+    healthcheck:
+      test: [ "CMD", "pg_isready" ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+    volumes:
+      - ./dump.sql:/docker-entrypoint-initdb.d/dump.sql
+
+secrets:
+  db-password:
+    file: db/password.txt

--- a/dev/db/password.txt
+++ b/dev/db/password.txt
@@ -1,0 +1,1 @@
+thisisapoproxpassword

--- a/dev/init_poprox_dev.sh
+++ b/dev/init_poprox_dev.sh
@@ -1,0 +1,21 @@
+# to use this file `source init_poprox_dev.sh`
+# this can be called from any folder (adjust the path as needed when sourcing the file)
+# you may find it useful to set up an alias.
+
+pushd "$( dirname "${BASH_SOURCE[0]}" )"
+
+export POPROX_DB_PASSWORD=`cat db/password.txt`
+export PG_PASSWORD=`cat db/password.txt`
+export POPROX_DB_USER='postgres'
+export POPROX_DB_HOST='127.0.0.1'
+export POPROX_DB_PORT='5433'
+export POPROX_DB_NAME='poprox'
+
+docker compose up -d --wait
+
+cd ../poprox-db
+alembic upgrade head
+
+# TODO: add dummy data to alembic
+
+popd

--- a/dev/make_dump.sh
+++ b/dev/make_dump.sh
@@ -1,0 +1,2 @@
+. ../poprox-db/.env.prod
+pg_dump -h $POPROX_DB_HOST --port $POPROX_DB_PORT --user $POPROX_DB_USER $POPROX_DB_NAME  --no-owner --exclude-table-data *account* --exclude-table-data clicks --exclude-table-data newsletters --exclude-table-data subscriptions --exclude-table-data expt_allocations > dump.sql

--- a/poprox-db/alembic.ini
+++ b/poprox-db/alembic.ini
@@ -1,0 +1,116 @@
+# A generic, single database configuration.
+
+[alembic]
+# path to migration scripts
+script_location = migrations
+
+# template used to generate migration file names; The default value is %%(rev)s_%%(slug)s
+# Uncomment the line below if you want the files to be prepended with date and time
+# see https://alembic.sqlalchemy.org/en/latest/tutorial.html#editing-the-ini-file
+# for all available tokens
+file_template = %%(year)d_%%(month).2d_%%(day).2d_%%(hour).2d%%(minute).2d-%%(rev)s_%%(slug)s
+
+# sys.path path, will be prepended to sys.path if present.
+# defaults to the current working directory.
+prepend_sys_path = .
+
+# timezone to use when rendering the date within the migration file
+# as well as the filename.
+# If specified, requires the python>=3.9 or backports.zoneinfo library.
+# Any required deps can installed by adding `alembic[tz]` to the pip requirements
+# string value is passed to ZoneInfo()
+# leave blank for localtime
+# timezone =
+
+# max length of characters to apply to the
+# "slug" field
+# truncate_slug_length = 40
+
+# set to 'true' to run the environment during
+# the 'revision' command, regardless of autogenerate
+# revision_environment = false
+
+# set to 'true' to allow .pyc and .pyo files without
+# a source .py file to be detected as revisions in the
+# versions/ directory
+# sourceless = false
+
+# version location specification; This defaults
+# to migrations/versions.  When using multiple version
+# directories, initial revisions must be specified with --version-path.
+# The path separator used here should be the separator specified by "version_path_separator" below.
+# version_locations = %(here)s/bar:%(here)s/bat:migrations/versions
+
+# version path separator; As mentioned above, this is the character used to split
+# version_locations. The default within new alembic.ini files is "os", which uses os.pathsep.
+# If this key is omitted entirely, it falls back to the legacy behavior of splitting on spaces and/or commas.
+# Valid values for version_path_separator are:
+#
+# version_path_separator = :
+# version_path_separator = ;
+# version_path_separator = space
+version_path_separator = os  # Use os.pathsep. Default configuration used for new projects.
+
+# set to 'true' to search source files recursively
+# in each "version_locations" directory
+# new in Alembic version 1.10
+# recursive_version_locations = false
+
+# the output encoding used when revision files
+# are written from script.py.mako
+# output_encoding = utf-8
+
+#sqlalchemy.url = postgresql://postgres:password@localhost/example
+
+
+[post_write_hooks]
+# post_write_hooks defines scripts or Python functions that are run
+# on newly generated revision scripts.  See the documentation for further
+# detail and examples
+
+# format using "black" - use the console_scripts runner, against the "black" entrypoint
+# hooks = black
+# black.type = console_scripts
+# black.entrypoint = black
+# black.options = -l 79 REVISION_SCRIPT_FILENAME
+
+# lint with attempts to fix using "ruff" - use the exec runner, execute a binary
+# hooks = ruff
+# ruff.type = exec
+# ruff.executable = %(here)s/.venv/bin/ruff
+# ruff.options = --fix REVISION_SCRIPT_FILENAME
+
+# Logging configuration
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/poprox-db/compose.yaml
+++ b/poprox-db/compose.yaml
@@ -1,0 +1,31 @@
+# Comments are provided throughout this file to help you get started.
+# If you need more help, visit the Docker compose reference guide at
+# https://docs.docker.com/go/compose-spec-reference/
+
+# The `db-data` volume persists the database data between container
+# restarts. The `db-password` secret is used to set the database
+# password. You must create `db/password.txt` and add a password of
+# your choosing to it before running `docker compose up`.
+services:
+  db:
+    restart: always
+    image: postgres
+    user: postgres
+    secrets:
+      - db-password
+    environment:
+      - POSTGRES_DB=poprox
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD_FILE=/run/secrets/db-password
+    ports:
+        - "127.0.0.1:5435:5432"
+
+    healthcheck:
+      test: [ "CMD", "pg_isready" ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+secrets:
+  db-password:
+    file: db/password.txt

--- a/poprox-db/db/password.txt
+++ b/poprox-db/db/password.txt
@@ -1,0 +1,1 @@
+thisisapoproxpassword

--- a/poprox-db/migrations/README
+++ b/poprox-db/migrations/README
@@ -1,0 +1,1 @@
+Generic single-database configuration.

--- a/poprox-db/migrations/env.py
+++ b/poprox-db/migrations/env.py
@@ -1,0 +1,87 @@
+import os
+
+from logging.config import fileConfig
+
+from sqlalchemy import engine_from_config
+from sqlalchemy import pool
+
+from alembic import context
+from dotenv import load_dotenv
+
+load_dotenv()
+# this is the Alembic Config object, which provides
+# access to the values within the .ini file in use.
+config = context.config
+
+# Interpret the config file for Python logging.
+# This line sets up loggers basically.
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+# add your model's MetaData object here
+# for 'autogenerate' support
+# from myapp import mymodel
+# target_metadata = mymodel.Base.metadata
+target_metadata = None
+
+# other values from the config, defined by the needs of env.py,
+# can be acquired:
+# my_important_option = config.get_main_option("my_important_option")
+# ... etc.
+
+db_user = os.environ.get("POPROX_DB_USER", "postgres")
+db_password = os.environ.get("POPROX_DB_PASSWORD", "")
+db_host = os.environ.get("POPROX_DB_HOST", "127.0.0.1")
+db_port = os.environ.get("POPROX_DB_PORT", 5432)
+db_name = os.environ.get("POPROX_DB_NAME", "poprox")
+
+DB_URL = f"postgresql://{db_user}:{db_password}@{db_host}:{db_port}/{db_name}"
+
+
+def run_migrations_offline() -> None:
+    """Run migrations in 'offline' mode.
+
+    This configures the context with just a URL
+    and not an Engine, though an Engine is acceptable
+    here as well.  By skipping the Engine creation
+    we don't even need a DBAPI to be available.
+
+    Calls to context.execute() here emit the given string to the
+    script output.
+
+    """
+    context.configure(
+        url=DB_URL,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    """Run migrations in 'online' mode.
+
+    In this scenario we need to create an Engine
+    and associate a connection with the context.
+
+    """
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section, {}) | {"sqlalchemy.url": DB_URL},
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata)
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/poprox-db/migrations/script.py.mako
+++ b/poprox-db/migrations/script.py.mako
@@ -1,0 +1,26 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+# revision identifiers, used by Alembic.
+revision: str = ${repr(up_revision)}
+down_revision: Union[str, None] = ${repr(down_revision)}
+branch_labels: Union[str, Sequence[str], None] = ${repr(branch_labels)}
+depends_on: Union[str, Sequence[str], None] = ${repr(depends_on)}
+
+
+def upgrade() -> None:
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade() -> None:
+    ${downgrades if downgrades else "pass"}

--- a/poprox-db/migrations/versions/2024_04_11_1410-b84ba9163a5d_create_account_table.py
+++ b/poprox-db/migrations/versions/2024_04_11_1410-b84ba9163a5d_create_account_table.py
@@ -1,0 +1,40 @@
+"""create account table
+
+Revision ID: b84ba9163a5d
+Revises: 
+Create Date: 2024-04-11 14:10:36.814127
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "b84ba9163a5d"
+down_revision: Union[str, None] = None
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "account",
+        sa.Column(
+            "account_id",
+            sa.UUID,
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        # sa.Column("full_name", sa.String),
+        sa.Column("email", sa.String, nullable=False),
+        sa.Column(
+            "created_at", sa.DateTime, nullable=False, server_default=sa.text("NOW()")
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("account")

--- a/poprox-db/migrations/versions/2024_04_12_1344-1496108a1b16_create_article_table.py
+++ b/poprox-db/migrations/versions/2024_04_12_1344-1496108a1b16_create_article_table.py
@@ -1,0 +1,51 @@
+"""create article table
+
+Revision ID: 1496108a1b16
+Revises: b84ba9163a5d
+Create Date: 2024-04-12 13:44:05.476707
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "1496108a1b16"
+down_revision: Union[str, None] = "b84ba9163a5d"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+# Article table
+# article_id: UUID
+# title: str
+# content: str
+# url: str
+# published_at: timestamp
+# created_at: timestamp
+def upgrade() -> None:
+    op.create_table(
+        "article",
+        sa.Column(
+            "article_id",
+            sa.UUID,
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column("title", sa.String, nullable=False),
+        sa.Column("content", sa.String),
+        sa.Column("url", sa.String, nullable=False),
+        sa.Column("published_at", sa.DateTime, nullable=False),
+        sa.Column(
+            "created_at", sa.DateTime, nullable=False, server_default=sa.text("NOW()")
+        ),
+    )
+    op.create_unique_constraint("uq_articles", "article", ("title", "url"))
+
+
+def downgrade() -> None:
+    op.drop_constraint("uq_articles", "article")
+    op.drop_table("article")

--- a/poprox-db/migrations/versions/2024_04_12_1346-6502e43e4cf6_create_newsletter_table.py
+++ b/poprox-db/migrations/versions/2024_04_12_1346-6502e43e4cf6_create_newsletter_table.py
@@ -1,0 +1,56 @@
+"""create newsletter table
+
+Revision ID: 6502e43e4cf6
+Revises: 1496108a1b16
+Create Date: 2024-04-12 13:46:34.347668
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "6502e43e4cf6"
+down_revision: Union[str, None] = "1496108a1b16"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+# Newsletter log table
+# newsletter_id: UUID
+# account_id: UUID (foreign key)
+# content: JSONB
+# html: str
+# created_at: timestamp
+def upgrade() -> None:
+    op.create_table(
+        "newsletter",
+        sa.Column(
+            "newsletter_id",
+            sa.UUID,
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column("account_id", sa.UUID, nullable=False),
+        sa.Column("content", sa.dialects.postgresql.JSONB),
+        sa.Column("html", sa.String, nullable=False),
+        sa.Column(
+            "created_at", sa.DateTime, nullable=False, server_default=sa.text("NOW()")
+        ),
+    )
+
+    op.create_foreign_key(
+        "fk_newsletter_account",
+        "newsletter",
+        "account",
+        ["account_id"],
+        ["account_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("fk_newsletter_account", "newsletter", type_="foreignkey")
+    op.drop_table("newsletter")

--- a/poprox-db/migrations/versions/2024_05_07_0930-519655a72d7c_create_impression_table.py
+++ b/poprox-db/migrations/versions/2024_05_07_0930-519655a72d7c_create_impression_table.py
@@ -1,0 +1,67 @@
+"""create impression table
+
+Revision ID: 519655a72d7c
+Revises: 6502e43e4cf6
+Create Date: 2024-05-07 09:30:20.103281
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "519655a72d7c"
+down_revision: Union[str, None] = "6502e43e4cf6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+# Impression log table
+# newsletter_id: UUID (foreign key)
+# article_id: UUID (foreign key)
+# created_at: timestamp
+def upgrade() -> None:
+    op.create_table(
+        "impression",
+        sa.Column("newsletter_id", sa.UUID, nullable=False),
+        sa.Column("article_id", sa.UUID, nullable=False),
+        sa.Column("position", sa.Integer, nullable=False),
+        sa.Column(
+            "created_at", sa.DateTime, nullable=False, server_default=sa.text("NOW()")
+        ),
+    )
+
+    op.create_unique_constraint(
+        "uq_newsletter_position", "impression", ("newsletter_id", "position")
+    )
+
+    op.create_check_constraint(
+        "ch_position_positive", "impression", sa.sql.column("position") > 0
+    )
+
+    op.create_foreign_key(
+        "fk_impression_newsletter",
+        "impression",
+        "newsletter",
+        ["newsletter_id"],
+        ["newsletter_id"],
+    )
+
+    op.create_foreign_key(
+        "fk_impression_article",
+        "impression",
+        "article",
+        ["article_id"],
+        ["article_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("uq_newsletter_position", "impression")
+    op.drop_constraint("ch_position_positive", "impression")
+    op.drop_constraint("fk_impression_newsletter", "impression", type_="foreignkey")
+    op.drop_constraint("fk_impression_article", "impression", type_="foreignkey")
+    op.drop_table("impression")

--- a/poprox-db/migrations/versions/2024_05_08_0931-a5be6e14d5ff_create_click_log_table.py
+++ b/poprox-db/migrations/versions/2024_05_08_0931-a5be6e14d5ff_create_click_log_table.py
@@ -1,0 +1,74 @@
+"""create click table
+
+Revision ID: a5be6e14d5ff
+Revises: 519655a72d7c
+Create Date: 2024-05-08 09:31:02.263478
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "a5be6e14d5ff"
+down_revision: Union[str, None] = "519655a72d7c"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+# Click table
+# click_id: int (primary)
+# account_id: UUID (foreign key)
+# newsletter_id: UUID (foreign key) <- the specific newsletter they clicked on
+# article_id: UUID (foreign key)
+# created_at: timestamp
+def upgrade() -> None:
+    op.create_table(
+        "click",
+        sa.Column(
+            "click_id",
+            sa.UUID,
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column("account_id", sa.UUID, nullable=False),
+        sa.Column("newsletter_id", sa.UUID),
+        sa.Column("article_id", sa.UUID, nullable=False),
+        sa.Column(
+            "created_at", sa.DateTime, nullable=False, server_default=sa.text("NOW()")
+        ),
+    )
+
+    op.create_foreign_key(
+        "fk_click_account",
+        "click",
+        "account",
+        ["account_id"],
+        ["account_id"],
+    )
+
+    op.create_foreign_key(
+        "fk_click_newsletter",
+        "click",
+        "newsletter",
+        ["newsletter_id"],
+        ["newsletter_id"],
+    )
+
+    op.create_foreign_key(
+        "fk_click_article",
+        "click",
+        "article",
+        ["article_id"],
+        ["article_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("fk_click_account", "click", type_="foreignkey")
+    op.drop_constraint("fk_click_newsletter", "click", type_="foreignkey")
+    op.drop_constraint("fk_click_article", "click", type_="foreignkey")
+    op.drop_table("click")

--- a/poprox-db/migrations/versions/2024_05_14_1531-7784f1ca77d3_add_entity_table.py
+++ b/poprox-db/migrations/versions/2024_05_14_1531-7784f1ca77d3_add_entity_table.py
@@ -1,0 +1,45 @@
+"""add entity table
+
+Revision ID: 7784f1ca77d3
+Revises: a5be6e14d5ff
+Create Date: 2024-05-14 15:31:53.092234
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB
+
+# revision identifiers, used by Alembic.
+revision: str = "7784f1ca77d3"
+down_revision: Union[str, None] = "a5be6e14d5ff"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "entities",
+        sa.Column(
+            "entity_id",
+            sa.UUID,
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column("entity_type", sa.String, nullable=False),
+        sa.Column("name", sa.String, nullable=False),
+        sa.Column("source", sa.String, nullable=False),
+        sa.Column("external_id", sa.String, nullable=True),
+        sa.Column("raw_data", JSONB, nullable=True),
+    )
+
+    op.create_unique_constraint(
+        "uq_entities", "entities", ("entity_type", "name", "source", "external_id")
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("uq_entities", "entities")
+    op.drop_table("entities")

--- a/poprox-db/migrations/versions/2024_05_14_1540-8c2b0c4c3ae5_add_article_entity_table.py
+++ b/poprox-db/migrations/versions/2024_05_14_1540-8c2b0c4c3ae5_add_article_entity_table.py
@@ -1,0 +1,64 @@
+"""add mentions table
+
+Revision ID: 8c2b0c4c3ae5
+Revises: 7784f1ca77d3
+Create Date: 2024-05-14 15:40:48.293198
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "8c2b0c4c3ae5"
+down_revision: Union[str, None] = "7784f1ca77d3"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "mentions",
+        sa.Column(
+            "mention_id",
+            sa.UUID,
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column("entity_id", sa.UUID, nullable=False),
+        sa.Column("article_id", sa.UUID, nullable=False),
+        sa.Column("source", sa.String, nullable=True),
+        sa.Column("relevance", sa.Double, nullable=False),
+    )
+
+    op.create_foreign_key(
+        "fk_mentions_article",
+        "mentions",
+        "article",
+        ["article_id"],
+        ["article_id"],
+        ondelete="RESTRICT",
+    )
+
+    op.create_foreign_key(
+        "fk_mentions_entity",
+        "mentions",
+        "entities",
+        ["entity_id"],
+        ["entity_id"],
+        ondelete="RESTRICT",
+    )
+
+    op.create_unique_constraint(
+        "uq_mentions", "mentions", ("entity_id", "article_id", "source")
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("uq_mentions", "mentions")
+    op.drop_constraint("fk_mentions_entity", "mentions", type_="foreignkey")
+    op.drop_constraint("fk_mentions_article", "mentions", type_="foreignkey")
+    op.drop_table("mentions")

--- a/poprox-db/migrations/versions/2024_05_16_0833-12db57e34931_pluralize_table_names.py
+++ b/poprox-db/migrations/versions/2024_05_16_0833-12db57e34931_pluralize_table_names.py
@@ -1,0 +1,34 @@
+"""pluralize table names
+
+Revision ID: 12db57e34931
+Revises: 8c2b0c4c3ae5
+Create Date: 2024-05-16 08:33:51.827319
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = "12db57e34931"
+down_revision: Union[str, None] = "8c2b0c4c3ae5"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade():
+    op.rename_table("account", "accounts")
+    op.rename_table("article", "articles")
+    op.rename_table("newsletter", "newsletters")
+    op.rename_table("impression", "impressions")
+    op.rename_table("click", "clicks")
+
+
+def downgrade():
+    op.rename_table("clicks", "click")
+    op.rename_table("impressions", "impression")
+    op.rename_table("newsletters", "newsletter")
+    op.rename_table("articles", "article")
+    op.rename_table("accounts", "account")

--- a/poprox-db/migrations/versions/2024_05_22_1251-abbe1a8bef82_create_experiments_table.py
+++ b/poprox-db/migrations/versions/2024_05_22_1251-abbe1a8bef82_create_experiments_table.py
@@ -1,0 +1,41 @@
+"""create experiments table
+
+Revision ID: abbe1a8bef82
+Revises: 12db57e34931
+Create Date: 2024-05-22 12:51:38.075973
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "abbe1a8bef82"
+down_revision: Union[str, None] = "12db57e34931"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "experiments",
+        sa.Column(
+            "experiment_id",
+            sa.UUID,
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column("description", sa.Text, nullable=True),
+        sa.Column("start_date", sa.Date, nullable=False),
+        sa.Column("end_date", sa.Date, nullable=False),
+        sa.Column(
+            "created_at", sa.DateTime, nullable=False, server_default=sa.text("NOW()")
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("experiments")

--- a/poprox-db/migrations/versions/2024_05_22_1259-b4e38c35ad49_create_experiment_sub_tables.py
+++ b/poprox-db/migrations/versions/2024_05_22_1259-b4e38c35ad49_create_experiment_sub_tables.py
@@ -1,0 +1,127 @@
+"""create experiment sub-tables
+
+Revision ID: b4e38c35ad49
+Revises: abbe1a8bef82
+Create Date: 2024-05-22 12:59:44.142662
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "b4e38c35ad49"
+down_revision: Union[str, None] = "abbe1a8bef82"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "expt_groups",
+        sa.Column(
+            "group_id",
+            sa.UUID,
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column("group_name", sa.String, nullable=False),
+        sa.Column("experiment_id", sa.UUID, nullable=False),
+        sa.Column(
+            "created_at", sa.DateTime, nullable=False, server_default=sa.text("NOW()")
+        ),
+    )
+
+    op.create_foreign_key(
+        "fk_expt_groups_experiment_id",
+        "expt_groups",
+        "experiments",
+        ["experiment_id"],
+        ["experiment_id"],
+    )
+
+    op.create_unique_constraint(
+        "uq_expt_groups_name_experiment", "expt_groups", ("group_name", "experiment_id")
+    )
+
+    op.create_table(
+        "expt_phases",
+        sa.Column(
+            "phase_id",
+            sa.UUID,
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column("phase_name", sa.String, nullable=False),
+        sa.Column("experiment_id", sa.UUID, nullable=False),
+        sa.Column("start_date", sa.Date, nullable=False),
+        sa.Column("end_date", sa.Date, nullable=False),
+        sa.Column(
+            "created_at", sa.DateTime, nullable=False, server_default=sa.text("NOW()")
+        ),
+    )
+
+    op.create_foreign_key(
+        "fk_expt_phases_experiment_id",
+        "expt_phases",
+        "experiments",
+        ["experiment_id"],
+        ["experiment_id"],
+    )
+
+    op.create_unique_constraint(
+        "uq_expt_phases_name_experiment", "expt_phases", ("phase_name", "experiment_id")
+    )
+
+    op.create_table(
+        "expt_recommenders",
+        sa.Column(
+            "recommender_id",
+            sa.UUID,
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column("recommender_name", sa.String, nullable=False),
+        sa.Column("endpoint_url", sa.String, nullable=False),
+        sa.Column("experiment_id", sa.UUID, nullable=False),
+        sa.Column(
+            "created_at", sa.DateTime, nullable=False, server_default=sa.text("NOW()")
+        ),
+    )
+
+    op.create_foreign_key(
+        "fk_expt_recommenders_experiment_id",
+        "expt_recommenders",
+        "experiments",
+        ["experiment_id"],
+        ["experiment_id"],
+    )
+
+    op.create_unique_constraint(
+        "uq_expt_recommenders_name_experiment",
+        "expt_recommenders",
+        ("recommender_name", "experiment_id"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        "fk_expt_recommenders_experiment_id", "expt_recommenders", type_="foreignkey"
+    )
+    op.drop_constraint("uq_expt_recommenders_name_experiment", "expt_recommenders")
+    op.drop_table("expt_recommenders")
+
+    op.drop_constraint(
+        "fk_expt_phases_experiment_id", "expt_phases", type_="foreignkey"
+    )
+    op.drop_constraint("uq_expt_phases_name_experiment", "expt_phases")
+    op.drop_table("expt_phases")
+
+    op.drop_constraint(
+        "fk_expt_groups_experiment_id", "expt_groups", type_="foreignkey"
+    )
+    op.drop_constraint("uq_expt_groups_name_experiment", "expt_groups")
+    op.drop_table("expt_groups")

--- a/poprox-db/migrations/versions/2024_05_22_1305-aad7bde678ba_create_experiment_treatments_table.py
+++ b/poprox-db/migrations/versions/2024_05_22_1305-aad7bde678ba_create_experiment_treatments_table.py
@@ -1,0 +1,83 @@
+"""create experiment treatments table
+
+Revision ID: aad7bde678ba
+Revises: b4e38c35ad49
+Create Date: 2024-05-22 13:05:19.632323
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "aad7bde678ba"
+down_revision: Union[str, None] = "b4e38c35ad49"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "expt_treatments",
+        sa.Column(
+            "treatment_id",
+            sa.UUID,
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column("recommender_id", sa.UUID, nullable=False),
+        sa.Column("phase_id", sa.UUID, nullable=False),
+        sa.Column("group_id", sa.UUID, nullable=False),
+        sa.Column(
+            "created_at", sa.DateTime, nullable=False, server_default=sa.text("NOW()")
+        ),
+    )
+
+    op.create_foreign_key(
+        "fk_expt_treatments_recommender_id",
+        "expt_treatments",
+        "expt_recommenders",
+        ["recommender_id"],
+        ["recommender_id"],
+    )
+
+    op.create_foreign_key(
+        "fk_expt_treatments_phase_id",
+        "expt_treatments",
+        "expt_phases",
+        ["phase_id"],
+        ["phase_id"],
+    )
+
+    op.create_foreign_key(
+        "fk_expt_treatments_group_id",
+        "expt_treatments",
+        "expt_groups",
+        ["group_id"],
+        ["group_id"],
+    )
+
+    op.create_unique_constraint(
+        "uq_expt_treatments_group_phase_ids",
+        "expt_treatments",
+        ("group_id", "phase_id"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("uq_expt_treatments_group_phase_ids", "expt_treatments")
+
+    op.drop_constraint(
+        "fk_expt_treatments_group_id", "expt_treatments", type_="foreignkey"
+    )
+    op.drop_constraint(
+        "fk_expt_treatments_phase_id", "expt_treatments", type_="foreignkey"
+    )
+    op.drop_constraint(
+        "fk_expt_treatments_recommender_id", "expt_treatments", type_="foreignkey"
+    )
+
+    op.drop_table("expt_treatments")

--- a/poprox-db/migrations/versions/2024_05_22_1309-adb103cc5e10_create_experiment_allocations_table.py
+++ b/poprox-db/migrations/versions/2024_05_22_1309-adb103cc5e10_create_experiment_allocations_table.py
@@ -1,0 +1,63 @@
+"""create experiment allocations table
+
+Revision ID: adb103cc5e10
+Revises: aad7bde678ba
+Create Date: 2024-05-22 13:09:57.172205
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "adb103cc5e10"
+down_revision: Union[str, None] = "aad7bde678ba"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "expt_allocations",
+        sa.Column(
+            "allocation_id",
+            sa.UUID,
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column("group_id", sa.UUID, nullable=False),
+        sa.Column("account_id", sa.UUID, nullable=False),
+        sa.Column(
+            "created_at", sa.DateTime, nullable=False, server_default=sa.text("NOW()")
+        ),
+    )
+
+    op.create_foreign_key(
+        "fk_expt_allocations_account_id",
+        "expt_allocations",
+        "accounts",
+        ["account_id"],
+        ["account_id"],
+    )
+
+    op.create_foreign_key(
+        "fk_expt_allocations_group_id",
+        "expt_allocations",
+        "expt_groups",
+        ["group_id"],
+        ["group_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        "fk_expt_allocations_group_id", "expt_allocations", type_="foreignkey"
+    )
+    op.drop_constraint(
+        "fk_expt_allocations_account_id", "expt_allocations", type_="foreignkey"
+    )
+
+    op.drop_table("expt_allocations")

--- a/poprox-db/migrations/versions/2024_06_03_1224-5111c14454e5_create_subscription_table.py
+++ b/poprox-db/migrations/versions/2024_06_03_1224-5111c14454e5_create_subscription_table.py
@@ -1,0 +1,56 @@
+"""create subscription table
+
+Revision ID: 5111c14454e5
+Revises: adb103cc5e10
+Create Date: 2024-06-03 12:24:19.591428
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '5111c14454e5'
+down_revision: Union[str, None] = 'adb103cc5e10'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "subscriptions",
+        sa.Column(
+            "subscription_id",
+            sa.UUID,
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column("account_id", sa.UUID, nullable=False),
+        sa.Column(
+            "started", sa.DateTime, nullable=False, server_default=sa.text("NOW()")
+        ),
+        sa.Column(
+            "ended", sa.DateTime, nullable=True, server_default=sa.null())
+        )
+
+    op.create_foreign_key(
+        "fk_subscriptions_account_id",
+        "subscriptions",
+        "accounts",
+        ["account_id"],
+        ["account_id"],
+    )
+
+    op.execute("insert into subscriptions (account_id) select account_id from accounts;")
+
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        "fk_subscriptions_account_id", "subscriptions", type_="foreignkey"
+    )
+
+    op.drop_table("subscriptions")
+

--- a/poprox-db/migrations/versions/2024_06_06_1548-10b32c41ed65_create_user_feature_preferences_table.py
+++ b/poprox-db/migrations/versions/2024_06_06_1548-10b32c41ed65_create_user_feature_preferences_table.py
@@ -1,0 +1,86 @@
+"""create user_feature_preferences table
+
+Revision ID: 10b32c41ed65
+Revises: 5111c14454e5
+Create Date: 2024-06-06 15:48:16.165974
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "10b32c41ed65"
+down_revision: Union[str, None] = "5111c14454e5"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "account_interest_log",
+        sa.Column(
+            "account_interest_log_id",
+            sa.UUID,
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column("account_id", sa.UUID, nullable=False),
+        sa.Column("entity_id", sa.UUID, nullable=False),
+        sa.Column("preference", sa.SmallInteger, nullable=True),
+        sa.Column("frequency", sa.SmallInteger, nullable=True),
+        sa.Column(
+            "created_at", sa.DateTime, nullable=False, server_default=sa.text("NOW()")
+        ),
+    )
+
+    op.create_foreign_key(
+        "fk_account_interest_log_accounts_account_id",
+        "account_interest_log",
+        "accounts",
+        ["account_id"],
+        ["account_id"],
+    )
+
+    op.create_foreign_key(
+        "fk_account_interest_log_accounts_entity_id",
+        "account_interest_log",
+        "entities",
+        ["entity_id"],
+        ["entity_id"],
+    )
+
+    # DISTINCT ON formally specifies that it returns the first row for each
+    # unique value of the keys it is distinct on. Since this is distinct on
+    # account and entity, it will return unique rows by account and entity.
+    # The chosen row would be determined by the order by statement which
+    # guarantees the first row for each account,entity pair is the most
+    # recently created one.
+
+    op.execute(
+        """
+        CREATE VIEW account_current_interest_view as
+        SELECT DISTINCT ON (account_id, entity_id) *
+        FROM account_interest_log
+        ORDER BY account_id, entity_id, created_at DESC;
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP VIEW account_current_interest_view;")
+
+    op.drop_constraint(
+        "fk_account_interest_log_accounts_account_id",
+        "account_interest_log",
+        type_="foreignkey",
+    )
+    op.drop_constraint(
+        "fk_account_interest_log_accounts_entity_id",
+        "account_interest_log",
+        type_="foreignkey",
+    )
+    op.drop_table("account_interest_log")

--- a/poprox-db/migrations/versions/2024_06_14_1112-ddf8de4a8fa5_add_account_status_field.py
+++ b/poprox-db/migrations/versions/2024_06_14_1112-ddf8de4a8fa5_add_account_status_field.py
@@ -1,0 +1,44 @@
+"""add account status field to account table to track progress when onboarding. as well field for tracking source
+
+Revision ID: ddf8de4a8fa5
+Revises: 10b32c41ed65
+Create Date: 2024-06-14 11:12:30.235044
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "ddf8de4a8fa5"
+down_revision: Union[str, None] = "10b32c41ed65"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "accounts",
+        sa.Column("status", sa.String(), default="new_account", nullable=True),
+    )
+    op.add_column(
+        "accounts",
+        sa.Column("source", sa.String(), nullable=True),
+    )
+
+    op.execute(
+        """
+        update accounts set status='new_account', source='team' where status is null;
+        """
+    )
+
+    op.alter_column("accounts", "status", nullable=False)
+    op.alter_column("accounts", "source", nullable=False)
+
+
+def downgrade() -> None:
+    op.drop_column("accounts", "status")
+    op.drop_column("accounts", "source")

--- a/poprox-db/migrations/versions/2024_06_14_1117-185dacfa54c0_add_consent_log_for_tracking_consent_at_.py
+++ b/poprox-db/migrations/versions/2024_06_14_1117-185dacfa54c0_add_consent_log_for_tracking_consent_at_.py
@@ -1,0 +1,56 @@
+"""add consent log for tracking consent at onboarding
+
+Revision ID: 185dacfa54c0
+Revises: ddf8de4a8fa5
+Create Date: 2024-06-14 11:17:07.191039
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "185dacfa54c0"
+down_revision: Union[str, None] = "ddf8de4a8fa5"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "account_consent_log",
+        sa.Column(
+            "account_consent_log_id",
+            sa.UUID,
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column("account_id", sa.UUID, nullable=False),
+        # The purpose of this field is twofold. First, it lets us track
+        # different _versions_ of our consent documents. Secondly, it
+        # lets this table be used for other consent documents (than a poprox-wide one) in the
+        sa.Column("document_name", sa.String, nullable=False),
+        sa.Column(
+            "created_at", sa.DateTime, nullable=False, server_default=sa.text("NOW()")
+        ),
+    )
+
+    op.create_foreign_key(
+        "fk_account_consent_log_accounts_account_id",
+        "account_consent_log",
+        "accounts",
+        ["account_id"],
+        ["account_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        "fk_account_consent_log_accounts_account_id",
+        "account_consent_log",
+        type_="foreignkey",
+    )
+    op.drop_table("account_consent_log")

--- a/poprox-db/migrations/versions/2024_07_01_0910-b705c3374dfa_add_raw_data_column_to_articles_table.py
+++ b/poprox-db/migrations/versions/2024_07_01_0910-b705c3374dfa_add_raw_data_column_to_articles_table.py
@@ -1,0 +1,40 @@
+"""add raw data column to articles table
+
+Revision ID: b705c3374dfa
+Revises: 185dacfa54c0
+Create Date: 2024-07-01 09:10:49.622969
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB
+
+# revision identifiers, used by Alembic.
+revision: str = "b705c3374dfa"
+down_revision: Union[str, None] = "185dacfa54c0"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "articles",
+        sa.Column("source", sa.String, nullable=True),
+    )
+    op.add_column(
+        "articles",
+        sa.Column("external_id", sa.String, nullable=True),
+    )
+    op.add_column(
+        "articles",
+        sa.Column("raw_data", JSONB, nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("articles", "source")
+    op.drop_column("articles", "external_id")
+    op.drop_column("articles", "raw_data")

--- a/poprox-db/migrations/versions/2024_07_05_1029-8fa118cae13f_add_article_images_table.py
+++ b/poprox-db/migrations/versions/2024_07_05_1029-8fa118cae13f_add_article_images_table.py
@@ -1,0 +1,46 @@
+"""add article images table
+
+Revision ID: 8fa118cae13f
+Revises: b705c3374dfa
+Create Date: 2024-07-05 10:29:25.409736
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB
+
+
+# revision identifiers, used by Alembic.
+revision: str = "8fa118cae13f"
+down_revision: Union[str, None] = "b705c3374dfa"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "images",
+        sa.Column(
+            "image_id",
+            sa.UUID,
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column("url", sa.String, nullable=False),
+        sa.Column("source", sa.String, nullable=True),
+        sa.Column("external_id", sa.String, nullable=True),
+        sa.Column("raw_data", JSONB, nullable=True),
+        sa.Column(
+            "created_at", sa.DateTime, nullable=False, server_default=sa.text("NOW()")
+        ),
+    )
+
+    op.create_unique_constraint("uq_images", "images", ("source", "external_id"))
+
+
+def downgrade() -> None:
+    op.drop_constraint("uq_images", "images")
+    op.drop_table("images")

--- a/poprox-db/migrations/versions/2024_07_10_1533-5d566fff8aaa_add_preview_image_url_column_to_.py
+++ b/poprox-db/migrations/versions/2024_07_10_1533-5d566fff8aaa_add_preview_image_url_column_to_.py
@@ -1,0 +1,39 @@
+"""add preview image url column to articles table
+
+Revision ID: 5d566fff8aaa
+Revises: 8fa118cae13f
+Create Date: 2024-07-10 15:33:02.131813
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "5d566fff8aaa"
+down_revision: Union[str, None] = "8fa118cae13f"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "articles",
+        sa.Column("preview_image_id", sa.UUID(), nullable=True),
+    )
+
+    op.create_foreign_key(
+        "fk_articles_preview_image_id",
+        "articles",
+        "images",
+        ["preview_image_id"],
+        ["image_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("fk_articles_preview_image_id", "articles", type_="foreignkey")
+    op.drop_column("articles", "preview_image_id")

--- a/poprox-db/requirements-dev.txt
+++ b/poprox-db/requirements-dev.txt
@@ -1,0 +1,6 @@
+configargparse
+sqlalchemy_utils
+yarl
+python-dotenv
+alembic
+pytest

--- a/poprox-db/requirements-dev.txt
+++ b/poprox-db/requirements-dev.txt
@@ -1,6 +1,0 @@
-configargparse
-sqlalchemy_utils
-yarl
-python-dotenv
-alembic
-pytest

--- a/poprox-db/test.sh
+++ b/poprox-db/test.sh
@@ -1,0 +1,6 @@
+export POPROX_DB_PASSWORD=`cat db/password.txt`
+export PG_PASSWORD=`cat db/password.txt`
+docker compose up -d
+sleep 5
+pytest
+docker compose down

--- a/poprox-db/tests/conftest.py
+++ b/poprox-db/tests/conftest.py
@@ -1,0 +1,109 @@
+import pytest
+from sqlalchemy import create_engine
+
+import os
+import uuid
+from collections import namedtuple
+from contextlib import contextmanager
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Optional, Union
+
+from alembic.config import Config
+from alembic.script import ScriptDirectory
+from configargparse import Namespace
+from sqlalchemy_utils import create_database, drop_database
+from yarl import URL
+
+db_password = os.environ.get("POPROX_DB_PASSWORD", "")
+
+PROJECT_PATH = Path(__file__).parent.parent.resolve()
+PROJECT_NAME = PROJECT_PATH.stem
+DEFAULT_PG_URL = f"postgresql://postgres:{db_password}@127.0.0.1:5435/poprox"
+
+
+def make_alembic_config(
+    cmd_opts: Union[Namespace, SimpleNamespace], base_path: str = PROJECT_PATH
+) -> Config:
+    # Replace path to alembic.ini file to absolute
+    if not os.path.isabs(cmd_opts.config):
+        cmd_opts.config = os.path.join(base_path, cmd_opts.config)
+
+    config = Config(file_=cmd_opts.config, ini_section=cmd_opts.name, cmd_opts=cmd_opts)
+
+    # Replace path to alembic folder to absolute
+    alembic_location = config.get_main_option("script_location")
+    if not os.path.isabs(alembic_location):
+        config.set_main_option(
+            "script_location", os.path.join(base_path, alembic_location)
+        )
+    if cmd_opts.pg_url:
+        config.set_main_option("sqlalchemy.url", cmd_opts.pg_url)
+
+    return config
+
+
+def alembic_config_from_url(pg_url: Optional[str] = None) -> Config:
+    """
+    Provides Python object, representing alembic.ini file.
+    """
+    cmd_options = SimpleNamespace(
+        config="alembic.ini",
+        name="alembic",
+        pg_url=pg_url,
+        raiseerr=False,
+        x=None,
+    )
+
+    return make_alembic_config(cmd_options)
+
+
+def get_revisions():
+    # Create Alembic configuration object
+    # (we don't need database for getting revisions list)
+    config = alembic_config_from_url()
+
+    # Get directory object with Alembic migrations
+    revisions_dir = ScriptDirectory.from_config(config)
+
+    # Get & sort migrations, from first to last
+    revisions = list(revisions_dir.walk_revisions("base", "heads"))
+    revisions.reverse()
+    return revisions
+
+
+@contextmanager
+def tmp_database(db_url: URL, suffix: str = "", **kwargs):
+    tmp_db_name = ".".join([uuid.uuid4().hex, PROJECT_NAME, suffix])
+    tmp_db_url = str(db_url.with_path(tmp_db_name))
+    create_database(tmp_db_url, **kwargs)
+
+    try:
+        yield tmp_db_url
+    finally:
+        drop_database(tmp_db_url)
+
+
+@pytest.fixture
+def postgres(pg_url):
+    """
+    Creates empty temporary database.
+    """
+    with tmp_database(pg_url, "pytest") as tmp_url:
+        yield tmp_url
+
+
+@pytest.fixture()
+def alembic_config(postgres):
+    """
+    Alembic configuration object, bound to temporary database.
+    """
+    return alembic_config_from_url(postgres)
+
+
+@pytest.fixture(scope="session")
+def pg_url():
+    """
+    Provides base PostgreSQL URL for creating temporary databases.
+    """
+    return URL(os.getenv("CI_POPROX_PG_URL", DEFAULT_PG_URL))

--- a/poprox-db/tests/test_stairstep.py
+++ b/poprox-db/tests/test_stairstep.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+
+import pytest
+from alembic.command import downgrade, upgrade
+from alembic.config import Config
+from alembic.script import Script
+
+from tests.conftest import get_revisions
+
+PROJECT_PATH = Path(__file__).parent.parent.resolve()
+
+
+@pytest.mark.parametrize("revision", get_revisions())
+def test_migrations_stairway(alembic_config: Config, revision: Script):
+    """
+    From https://github.com/alvassin/alembic-quickstart
+
+    Test can find forgotten downgrade methods, undeleted data types in downgrade
+    methods, typos and many other errors.
+
+    Does not require any maintenance - you just add it once to check 80% of typos
+    and mistakes in migrations forever.
+    """
+    upgrade(alembic_config, revision.revision)
+
+    # We need -1 for downgrading first migration (its down_revision is None)
+    downgrade(alembic_config, revision.down_revision or "-1")
+    upgrade(alembic_config, revision.revision)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,17 @@ dependencies = [
   "poprox-concepts@git+https://github.com/CCRI-POPROX/poprox-concepts.git",
 ]
 
+[project.optional-dependencies]
+dev = [
+  "alembic",
+  "sqlalchemy_utils",
+  "yarl",
+  "python-dotenv",
+  "configargparse",
+  "coverage[toml]>=6.5",
+  "pytest",
+]
+
 [project.urls]
 Documentation = "https://github.com/ccri-poprox/poprox-storage#readme"
 Issues = "https://github.com/ccri-poprox/poprox-storage/issues"
@@ -33,7 +44,16 @@ allow-direct-references = true
 path = "src/poprox_storage/__about__.py"
 
 [tool.hatch.envs.default]
-dependencies = ["coverage[toml]>=6.5", "pytest"]
+dependencies = [
+  "alembic",
+  "sqlalchemy_utils",
+  "yarl",
+  "python-dotenv",
+  "configargparse",
+  "coverage[toml]>=6.5",
+  "pytest",
+]
+
 [tool.hatch.envs.default.scripts]
 test = "pytest {args:tests}"
 test-cov = "coverage run -m pytest {args:tests}"


### PR DESCRIPTION
This is a full copy of the contents of the `poprox-db` and `dev` directories, with only minor modifications:
* The dev dependencies have been moved from `requirements-dev.txt` into `pyproject.toml`
* The README has been updated to contain instructions for installing the dev dependencies