### PR TITLE
Rename repository methods to use store/fetch/update/remove

### DIFF
--- a/src/poprox_storage/repositories/account_interest_log.py
+++ b/src/poprox_storage/repositories/account_interest_log.py
@@ -22,7 +22,7 @@ class DbAccountInterestRepository(DatabaseRepository):
             "account_interest_log", "entities", "account_current_interest_view"
         )
 
-    def insert_topic_preference(
+    def store_topic_preference(
         self, account_id: UUID, entity_id: UUID, preference: int, frequency: int
     ) -> Optional[UUID]:
         interest_log_tbl = self.tables["account_interest_log"]
@@ -36,8 +36,9 @@ class DbAccountInterestRepository(DatabaseRepository):
                 "frequency": frequency,
             },
         )
+    
 
-    def insert_topic_preferences(
+    def store_topic_preferences(
         self, account_id: UUID, interests: List[AccountInterest]
     ) -> int:
         failed = 0
@@ -59,7 +60,7 @@ class DbAccountInterestRepository(DatabaseRepository):
                 failed += 1
         return failed
 
-    def lookup_entity_by_name(self, entity_name: str) -> Optional[UUID]:
+    def fetch_entity_by_name(self, entity_name: str) -> Optional[UUID]:
         entity_tbl = self.tables["entities"]
 
         query = entity_tbl.select().filter(
@@ -71,7 +72,8 @@ class DbAccountInterestRepository(DatabaseRepository):
             result = result.entity_id
         return result
 
-    def get_topic_preferences(self, account_id: UUID) -> List[AccountInterest]:
+
+    def fetch_topic_preferences(self, account_id: UUID) -> List[AccountInterest]:
         current_interest_tbl = self.tables["account_current_interest_view"]
         entity_tbl = self.tables["entities"]
         query = (
@@ -98,3 +100,8 @@ class DbAccountInterestRepository(DatabaseRepository):
             for row in results
         ]
         return results
+
+    insert_topic_preference = store_topic_preference
+    insert_topic_preferences = store_topic_preferences
+    lookup_entity_by_name = fetch_entity_by_name
+    get_topic_preferences = fetch_topic_preferences

--- a/src/poprox_storage/repositories/accounts.py
+++ b/src/poprox_storage/repositories/accounts.py
@@ -63,7 +63,7 @@ class DbAccountRepository(DatabaseRepository):
             return accounts[0]
         return None
 
-    def create_new_account(self, email: str, source: str) -> Account:
+    def store_new_account(self, email: str, source: str) -> Account:
         account_tbl = self.tables["accounts"]
         query = (
             sqlalchemy.insert(account_tbl)
@@ -74,6 +74,7 @@ class DbAccountRepository(DatabaseRepository):
         )
         row = self.conn.execute(query).one_or_none()
         return Account(account_id=row.account_id, email=row.email, status=row.status)
+
 
     def fetch_unassigned_accounts(self, start_date: date, end_date: date):
         account_tbl = self.tables["accounts"]
@@ -138,14 +139,14 @@ class DbAccountRepository(DatabaseRepository):
             result = result.subscription_id
         return result
 
-    def create_subscription_for_account(self, account_id: UUID):
+    def store_subscription_for_account(self, account_id: UUID):
         subscription_tbl = self.tables["subscriptions"]
 
         create_query = subscription_tbl.insert().values(account_id=account_id)
         if self.fetch_subscription_for_account(account_id) is None:
             self.conn.execute(create_query)
 
-    def end_subscription_for_account(self, account_id: UUID):
+    def remove_subscription_for_account(self, account_id: UUID):
         subscription_tbl = self.tables["subscriptions"]
         delete_query = (
             subscription_tbl.update()
@@ -157,7 +158,7 @@ class DbAccountRepository(DatabaseRepository):
         )
         self.conn.execute(delete_query)
 
-    def record_consent(self, account_id: UUID, document_name: str):
+    def store_consent(self, account_id: UUID, document_name: str):
         consent_tbl = self.tables["account_consent_log"]
         query = sqlalchemy.insert(consent_tbl).values(
             account_id=account_id, document_name=document_name
@@ -172,3 +173,8 @@ class DbAccountRepository(DatabaseRepository):
             .where(account_tbl.c.account_id == account_id)
         )
         self.conn.execute(query)
+
+    create_new_account = store_new_account
+    create_subscription_for_account = store_subscription_for_account
+    end_subscription_for_account = remove_subscription_for_account
+    record_consent = store_consent

--- a/src/poprox_storage/repositories/articles.py
+++ b/src/poprox_storage/repositories/articles.py
@@ -31,31 +31,31 @@ class DbArticleRepository(DatabaseRepository):
             "impressions",
         )
 
-    def get_todays_articles(self) -> list[Article]:
+    def fetch_todays_articles(self) -> list[Article]:
         return self.get_articles_since(days_ago=1)
 
-    def get_past_articles(self) -> list[Article]:
+    def fetch_past_articles(self) -> list[Article]:
         return self.get_articles_before(days_ago=1)
 
-    def get_articles_since(self, days_ago=1) -> list[Article]:
+    def fetch_articles_since(self, days_ago=1) -> list[Article]:
         article_table = self.tables["articles"]
         return self._get_articles(
             article_table,
             article_table.c.published_at > datetime.now() - timedelta(days=days_ago),
         )
 
-    def get_articles_before(self, days_ago=1) -> list[Article]:
+    def fetch_articles_before(self, days_ago=1) -> list[Article]:
         article_table = self.tables["articles"]
         return self._get_articles(
             article_table,
             article_table.c.published_at < datetime.now() - timedelta(days=days_ago),
         )
 
-    def get_articles_by_id(self, ids: list[UUID]) -> list[Article]:
+    def fetch_articles_by_id(self, ids: list[UUID]) -> list[Article]:
         article_table = self.tables["articles"]
         return self._get_articles(article_table, article_table.c.article_id.in_(ids))
 
-    def get_article_mentions(self, articles: list[Article]) -> list[Article]:
+    def fetch_article_mentions(self, articles: list[Article]) -> list[Article]:
         article_lookup = {article.article_id: article for article in articles}
         article_ids = [article.article_id for article in articles]
 
@@ -101,7 +101,7 @@ class DbArticleRepository(DatabaseRepository):
         return_val = list(article_lookup.values())
         return return_val
 
-    def lookup_article_by_url(self, article_url: str, newsletter_id: UUID | None = None) -> UUID | None:
+    def fetch_article_by_url(self, article_url: str, newsletter_id: UUID | None = None) -> UUID | None:
         impression_table = self.tables["impressions"]
         article_table = self.tables["articles"]
 
@@ -118,7 +118,15 @@ class DbArticleRepository(DatabaseRepository):
         else:
             return None
 
-    def insert_articles(self, articles: list[Article], *, mentions=False, progress=False):
+    get_todays_articles = fetch_todays_articles
+    get_past_articles = fetch_past_articles
+    get_articles_since = fetch_articles_since
+    get_articles_before = fetch_articles_before
+    get_articles_by_id = fetch_articles_by_id
+    get_article_mentions = fetch_article_mentions
+    lookup_article_by_url = fetch_article_by_url
+
+    def store_articles(self, articles: list[Article], *, mentions=False, progress=False):
         failed = 0
 
         if progress:
@@ -142,13 +150,13 @@ class DbArticleRepository(DatabaseRepository):
 
         return failed
 
-    def insert_article(self, article: Article) -> UUID | None:
+    def store_article(self, article: Article) -> UUID | None:
         return self._insert_model("articles", article, exclude={"article_id", "mentions"}, constraint="uq_articles")
 
-    def insert_entity(self, entity: Entity) -> UUID | None:
+    def store_entity(self, entity: Entity) -> UUID | None:
         return self._insert_model("entities", entity, exclude={"entity_id"}, constraint="uq_entities")
 
-    def insert_mention(self, mention: Mention) -> UUID | None:
+    def store_mention(self, mention: Mention) -> UUID | None:
         return self._insert_model(
             "mentions",
             mention,
@@ -156,6 +164,11 @@ class DbArticleRepository(DatabaseRepository):
             addl_fields={"entity_id": mention.entity.entity_id},
             constraint="uq_mentions",
         )
+    
+    insert_articles = store_articles
+    insert_article = store_article
+    insert_entity = store_entity
+    insert_mention = store_mention
 
     def _get_articles(self, article_table, where_clause=None) -> list[Article]:
         query = article_table.select()
@@ -183,7 +196,7 @@ class S3ArticleRepository(S3Repository):
         super().__init__(bucket_name)
         self.s3_client = boto3.client("s3")
 
-    def list_news_files(self, prefix, days_back=None):
+    def fetch_news_files(self, prefix, days_back=None):
         """
         Retrieve the names of AP news files from S3 in sorted order
 
@@ -208,13 +221,13 @@ class S3ArticleRepository(S3Repository):
             files = files[:days_back]
 
         return [f["Key"] for f in files]
-
-    def get_articles_from_file(self, file_key):
+    
+    def fetch_articles_from_file(self, file_key):
         file_contents = self._get_s3_file(file_key)
         articles = extract_articles(file_contents)
         return articles
 
-    def get_articles_from_files(self, file_keys):
+    def fetch_articles_from_files(self, file_keys):
         articles = []
 
         for key in file_keys:
@@ -223,7 +236,7 @@ class S3ArticleRepository(S3Repository):
 
         return articles
 
-    def get_historical_articles(self) -> list[Article]:
+    def fetch_historical_articles(self) -> list[Article]:
         response = s3.get_object(bucket_name=DEV_BUCKET_NAME, key=NEWS_FILE_KEY).get("Body").read()
         raw_articles = json.loads(response)
         articles = [
@@ -240,6 +253,11 @@ class S3ArticleRepository(S3Repository):
         ]
 
         return articles
+    
+    list_news_files = fetch_news_files
+    get_articles_from_file = fetch_articles_from_file
+    get_articles_from_files = fetch_articles_from_files
+    get_historical_articles = fetch_historical_articles
 
 
 def extract_articles(news_file_content) -> list[Article]:

--- a/src/poprox_storage/repositories/clicks.py
+++ b/src/poprox_storage/repositories/clicks.py
@@ -34,7 +34,7 @@ class DbClicksRepository(DatabaseRepository):
         super().__init__(connection)
         self.tables = self._load_tables("clicks")
 
-    def track_click_in_database(self, newsletter_id, account_id, article_id):
+    def store_click(self, newsletter_id, account_id, article_id):
         click_table = self.tables["clicks"]
         with self.conn.begin():
             stmt = insert(click_table).values(
@@ -44,7 +44,7 @@ class DbClicksRepository(DatabaseRepository):
             )
             self.conn.execute(stmt)
 
-    def get_clicks(self, accounts: list[Account]) -> dict[UUID, ClickHistory]:
+    def fetch_clicks(self, accounts: list[Account]) -> dict[UUID, ClickHistory]:
         click_table = self.tables["clicks"]
 
         click_query = select(click_table.c.account_id, click_table.c.article_id).where(
@@ -66,3 +66,6 @@ class DbClicksRepository(DatabaseRepository):
             histories[account_id] = ClickHistory(article_ids=user_clicks)
 
         return histories
+
+    track_click_in_database = store_click
+    get_clicks = fetch_clicks

--- a/src/poprox_storage/repositories/experiments.py
+++ b/src/poprox_storage/repositories/experiments.py
@@ -55,7 +55,7 @@ class DbExperimentRepository(DatabaseRepository):
 
         return experiment_id
 
-    def get_active_expt_group_ids(self, date: datetime.date | None = None) -> list[UUID]:
+    def fetch_active_expt_group_ids(self, date: datetime.date | None = None) -> list[UUID]:
         groups_tbl = self.tables["expt_groups"]
         phases_tbl = self.tables["expt_phases"]
         treatments_tbl = self.tables["expt_treatments"]
@@ -75,7 +75,7 @@ class DbExperimentRepository(DatabaseRepository):
 
         return self._id_query(groups_query)
 
-    def get_active_expt_endpoint_urls(self, date: datetime.date | None = None) -> dict[UUID, str]:
+    def fetch_active_expt_endpoint_urls(self, date: datetime.date | None = None) -> dict[UUID, str]:
         groups_tbl = self.tables["expt_groups"]
         phases_tbl = self.tables["expt_phases"]
         recommenders_tbl = self.tables["expt_recommenders"]
@@ -104,7 +104,8 @@ class DbExperimentRepository(DatabaseRepository):
 
         return recommender_lookup_by_group
 
-    def get_active_expt_allocations(self, date: datetime.date | None = None) -> dict[UUID, Allocation]:
+
+    def fetch_active_expt_allocations(self, date: datetime.date | None = None) -> dict[UUID, Allocation]:
         allocations_tbl = self.tables["expt_allocations"]
 
         group_ids = self.get_active_expt_group_ids(date)
@@ -122,6 +123,10 @@ class DbExperimentRepository(DatabaseRepository):
         }
 
         return group_lookup_by_account
+
+    get_active_expt_group_ids = fetch_active_expt_group_ids
+    get_active_expt_endpoint_urls = fetch_active_expt_endpoint_urls
+    get_active_expt_allocations = fetch_active_expt_allocations
 
     def _insert_experiment(self, experiment: Experiment) -> UUID | None:
         return self._insert_model("experiments", experiment, exclude={"phases"}, commit=False)

--- a/src/poprox_storage/repositories/images.py
+++ b/src/poprox_storage/repositories/images.py
@@ -23,7 +23,7 @@ class DbImageRepository(DatabaseRepository):
         super().__init__(connection)
         self.tables = self._load_tables("images")
 
-    def insert_images(self, images: list[Image], *, progress=False):
+    def store_images(self, images: list[Image], *, progress=False):
         failed = 0
 
         if progress:
@@ -40,11 +40,14 @@ class DbImageRepository(DatabaseRepository):
                 failed += 1
 
         return failed
-
-    def insert_image(self, image: Image) -> UUID | None:
+    
+    def store_image(self, image: Image) -> UUID | None:
         return self._insert_model(
             "images", image, exclude={"image_id"}, constraint="uq_images"
         )
+    
+    insert_images = store_images
+    insert_image = store_image
 
     def fetch_image_by_external_id(self, external_id: str) -> Image | None:
         image_table = self.tables["images"]
@@ -88,7 +91,7 @@ class S3ImageRepository(S3Repository):
         super().__init__(bucket_name)
         self.s3_client = boto3.client("s3")
 
-    def list_image_files(self, prefix, days_back=None):
+    def fetch_image_file_keys(self, prefix, days_back=None):
         """
         Retrieve the names of AP image files from S3 in sorted order
 
@@ -116,11 +119,11 @@ class S3ImageRepository(S3Repository):
 
         return [f["Key"] for f in files]
 
-    def get_images_from_file(self, file_key):
+    def fetch_images_from_file(self, file_key):
         file_contents = self._get_s3_file(file_key)
         return extract_images(file_contents)
 
-    def get_images_from_files(self, file_keys):
+    def fetch_images_from_files(self, file_keys):
         images = []
 
         for key in file_keys:
@@ -128,6 +131,10 @@ class S3ImageRepository(S3Repository):
             images.extend(extracted)
 
         return images
+    
+    list_image_files = fetch_image_file_keys
+    get_images_from_file = fetch_images_from_file
+    get_images_from_files = fetch_images_from_files
 
 
 def extract_images(img_file_content) -> list[Image]:

--- a/src/poprox_storage/repositories/newsletters.py
+++ b/src/poprox_storage/repositories/newsletters.py
@@ -17,7 +17,7 @@ class DbNewsletterRepository(DatabaseRepository):
             "impressions",
         )
 
-    def log_newsletter_content(
+    def store_newsletter(
         self, newsletter_id, account_id, recommended_articles, article_html
     ):
         # TODO: Add the email title to the newsletter table
@@ -40,3 +40,5 @@ class DbNewsletterRepository(DatabaseRepository):
                     position=1 + position,
                 )
                 self.conn.execute(stmt)
+
+    log_newsletter_content = store_newsletter

--- a/src/poprox_storage/repositories/qualtrics_survey.py
+++ b/src/poprox_storage/repositories/qualtrics_survey.py
@@ -35,7 +35,7 @@ class DbQualtricsSurveyRepository(DatabaseRepository):
             "qualtrics_survey_responses",
         )
 
-    def get_active_surveys(self) -> List[QualtricsSurvey]:
+    def fetch_active_surveys(self) -> List[QualtricsSurvey]:
         survey_table = self.tables["qualtrics_surveys"]
         query = select(
             survey_table.c.survey_id,
@@ -55,6 +55,8 @@ class DbQualtricsSurveyRepository(DatabaseRepository):
             )
             for row in results
         ]
+    
+    get_active_surveys = fetch_active_surveys
 
     def update_survey(self, survey: QualtricsSurvey) -> Optional[UUID]:
         survey_table = self.tables["qualtrics_surveys"]
@@ -65,7 +67,7 @@ class DbQualtricsSurveyRepository(DatabaseRepository):
             constraint="uq_qualtrics_id",
         )
 
-    def create_survey_instance(
+    def store_survey_instance(
         self, survey: QualtricsSurvey, account_id: UUID
     ) -> Optional[UUID]:
         survey_instance_table = self.tables["qualtrics_survey_instances"]
@@ -75,7 +77,7 @@ class DbQualtricsSurveyRepository(DatabaseRepository):
             {"survey_id": survey.survey_id, "account_id": account_id},
         )
 
-    def create_or_update_survey_response(
+    def store_survey_response(
         self, response: QualtricsSurveyResponse
     ) -> Optional[UUID]:
         survey_responses_table = self.tables["qualtrics_survey_responses"]
@@ -89,3 +91,6 @@ class DbQualtricsSurveyRepository(DatabaseRepository):
             },
             constraint="uq_qualtrics_response_id",
         )
+
+    create_survey_instance = store_survey_instance
+    create_or_update_survey_response = store_survey_response


### PR DESCRIPTION
We talked about this change recently in a few different conversations, so I went ahead and put it together. These methods are basically CRUD, but the semantics of create/read/update/delete aren't quite right here. Since our domain objects aren't coupled to the underlying storage technologies, we can _create_ an account with the normal Python constructor `Account(email=...)` without storing it anywhere and _then_ decide where/how to store it. This should really come in handy with some of our upcoming data export work, because it will mean that we can create e.g. id mapping objects that are never stored in the database but instead written to files while maintaining an easy path for importing them into the database.

It also opens up a possibility for testing our platform code without the database, which is that we can use an `InMemoryWhateverRepository` class (potentially from this repo) that has all the same methods and does all the same things but just holds the objects in memory instead of storing them anywhere. In this repo, we can test that the `Db/S3/InMemory` implementations are interchangeable, and in `poprox-platform` we can then avoid having to create mocks for the `Db/S3` repositories or stub their individual methods but still be able to test that the platform code works the way we expect without involving a database or S3.