### PR TITLE
Fix Newsletter Export Data Type Complaint with Json Dumps

### DIFF
--- a/src/poprox_storage/repositories/newsletters.py
+++ b/src/poprox_storage/repositories/newsletters.py
@@ -59,6 +59,8 @@ class DbNewsletterRepository(DatabaseRepository):
         for row in newsletter_result:
             raw_articles = []
             for article_json in row.content:
+                if isinstance(article_json, dict):
+                    article_json = json.dump(article_json)
                 raw_articles.append(json.loads(article_json))
             articles = [
                 Article(

--- a/src/poprox_storage/repositories/newsletters.py
+++ b/src/poprox_storage/repositories/newsletters.py
@@ -60,7 +60,7 @@ class DbNewsletterRepository(DatabaseRepository):
             raw_articles = []
             for article_json in row.content:
                 if isinstance(article_json, dict):
-                    article_json = json.dump(article_json)
+                    article_json = json.dumps(article_json)
                 raw_articles.append(json.loads(article_json))
             articles = [
                 Article(

--- a/src/poprox_storage/repositories/newsletters.py
+++ b/src/poprox_storage/repositories/newsletters.py
@@ -64,11 +64,12 @@ class DbNewsletterRepository(DatabaseRepository):
                 raw_articles.append(json.loads(article_json))
             articles = [
                 Article(
+                    article_id=raw["article_id"],
                     title=raw["title"],
-                    content=raw.get("description", None),
+                    content=raw.get("content", None),
                     url=raw["url"],
                     published_at=datetime.strptime(
-                        raw.get("published_time", "1970-01-01T00:00:00")[:19],
+                        raw.get("published_at", "1970-01-01T00:00:00")[:19],
                         "%Y-%m-%dT%H:%M:%S",
                     ),
                 )

--- a/tests/test_newsletters.py
+++ b/tests/test_newsletters.py
@@ -37,7 +37,7 @@ def test_fetch_newsletters(pg_url: str):
         dbNewsletterRepository = DbNewsletterRepository(conn)
 
         newsletter_1_articles = [
-            Article(title="title-1", content = "article content 1", url="url-1"),
+            Article(title="title-1", content="article content 1", url="url-1"),
             Article(title="title-2", url="url-2"),
         ]
 

--- a/tests/test_newsletters.py
+++ b/tests/test_newsletters.py
@@ -37,7 +37,7 @@ def test_fetch_newsletters(pg_url: str):
         dbNewsletterRepository = DbNewsletterRepository(conn)
 
         newsletter_1_articles = [
-            Article(title="title-1", url="url-1"),
+            Article(title="title-1", content = "article content 1", url="url-1"),
             Article(title="title-2", url="url-2"),
         ]
 
@@ -73,6 +73,7 @@ def test_fetch_newsletters(pg_url: str):
         user_1_newsletter = results[user_account_1.account_id]
         assert 1 == len(user_1_newsletter)
         assert 2 == len(user_1_newsletter[newsletter_1_id])
+        assert "article content 1" == user_1_newsletter[newsletter_1_id][0].content
 
         user_2_newsletter = results[user_account_2.account_id]
         assert 1 == len(user_2_newsletter)

--- a/tests/test_newsletters.py
+++ b/tests/test_newsletters.py
@@ -42,7 +42,7 @@ def test_fetch_newsletters(pg_url: str):
         ]
 
         newsletter_2_articles = [
-            Article(title="title-3", url="url-1"),
+            Article(title="title-3", content="article 3 content", url="url-1"),
         ]
 
         user_account_1 = dbAccountRepository.create_new_account(email="user-1@gmail.com", source="test")

--- a/tests/test_newsletters.py
+++ b/tests/test_newsletters.py
@@ -42,7 +42,7 @@ def test_fetch_newsletters(pg_url: str):
         ]
 
         newsletter_2_articles = [
-            Article(title="title-3", content="article 3 content", url="url-1"),
+            Article(title="title-3", url="url-1"),
         ]
 
         user_account_1 = dbAccountRepository.create_new_account(email="user-1@gmail.com", source="test")


### PR DESCRIPTION
While testing the PR of poprox-platform: https://github.com/CCRI-POPROX/poprox-platform/pull/131, we encountered an export error that would complain about json export; with this data type check we can get rid of it.