### PR TITLE
Only fetch the latest version of each article

### DIFF
--- a/src/poprox_storage/repositories/data_stores/db.py
+++ b/src/poprox_storage/repositories/data_stores/db.py
@@ -20,7 +20,7 @@ class DatabaseRepository:
     def __init__(self, connection: Connection):
         self.conn: Connection = connection
 
-    def _load_tables(self, *args):
+    def _load_tables(self, *args) -> dict[str, Table]:
         metadata = MetaData()
         tables = {}
         for table_name in args:


### PR DESCRIPTION
This will help us avoid duplicate articles in the newsletter caused by updates from AP's side that they provide to us as separate articles in the feed.