### PR TITLE
Remove repository method name aliases

### DIFF
--- a/src/poprox_storage/repositories/account_interest_log.py
+++ b/src/poprox_storage/repositories/account_interest_log.py
@@ -33,7 +33,7 @@ class DbAccountInterestRepository(DatabaseRepository):
 
         for interest in interests:
             try:
-                log_id = self.insert_topic_preference(
+                log_id = self.store_topic_preference(
                     account_id,
                     interest.entity_id,
                     interest.preference,
@@ -82,8 +82,3 @@ class DbAccountInterestRepository(DatabaseRepository):
             for row in results
         ]
         return results
-
-    insert_topic_preference = store_topic_preference
-    insert_topic_preferences = store_topic_preferences
-    lookup_entity_by_name = fetch_entity_by_name
-    get_topic_preferences = fetch_topic_preferences

--- a/src/poprox_storage/repositories/accounts.py
+++ b/src/poprox_storage/repositories/accounts.py
@@ -67,7 +67,7 @@ class DbAccountRepository(DatabaseRepository):
 
     def fetch_unassigned_accounts(self, start_date: date, end_date: date):
         account_tbl = self.tables["accounts"]
-        allocation_tbl = self.tables["expt_allocations"]
+        assignment_tbl = self.tables["expt_assignments"]
         phase_tbl = self.tables["expt_phases"]
         treatment_tbl = self.tables["expt_treatments"]
 
@@ -93,11 +93,11 @@ class DbAccountRepository(DatabaseRepository):
         group_ids = self._id_query(group_query)
 
         # Find the users allocated to those groups
-        allocation_query = select(allocation_tbl.c.account_id).where(allocation_tbl.c.group_id.in_(group_ids))
-        allocation_account_ids = self._id_query(allocation_query)
+        assignment_query = select(assignment_tbl.c.account_id).where(assignment_tbl.c.group_id.in_(group_ids))
+        assignment_account_ids = self._id_query(assignment_query)
 
-        # Find all the users who aren't in the allocations above
-        account_query = select(account_tbl.c.account_id).where(account_tbl.c.account_id.not_in(allocation_account_ids))
+        # Find all the users who aren't in the assignments above
+        account_query = select(account_tbl.c.account_id).where(account_tbl.c.account_id.not_in(assignment_account_ids))
         account_ids = self._id_query(account_query)
 
         return self.fetch_accounts(account_ids)
@@ -179,8 +179,3 @@ class DbAccountRepository(DatabaseRepository):
             data=link_data.data,
         )
         self.conn.execute(query)
-
-    create_new_account = store_new_account
-    create_subscription_for_account = store_subscription_for_account
-    end_subscription_for_account = remove_subscription_for_account
-    record_consent = store_consent

--- a/src/poprox_storage/repositories/clicks.py
+++ b/src/poprox_storage/repositories/clicks.py
@@ -20,7 +20,7 @@ class S3ClicksRepository(S3Repository):
     def __init__(self, bucket_name):
         super().__init__(bucket_name)
 
-    def get_clicks_from_dev_file(self, file_key):
+    def fetch_clicks_from_dev_file(self, file_key):
         try:
             click_data = json.loads(s3.get_object(self.bucket_name, file_key).get("Body").read())
         except PoproxAwsUtilitiesException:
@@ -97,7 +97,3 @@ class DbClicksRepository(DatabaseRepository):
             histories[account_id] = user_clicks
 
         return histories
-
-    track_click_in_database = store_click
-    get_clicks = fetch_clicks
-    get_clicks_between = fetch_clicks_between

--- a/src/poprox_storage/repositories/experiments.py
+++ b/src/poprox_storage/repositories/experiments.py
@@ -39,8 +39,8 @@ class DbExperimentRepository(DatabaseRepository):
             for group in experiment.groups:
                 group.group_id = self._insert_expt_group(experiment_id, group)
                 for account in assignments.get(group.name, []):
-                    allocation = Assignment(account_id=account.account_id, group_id=group.group_id)
-                    self._insert_expt_assignment(allocation)
+                    assignment = Assignment(account_id=account.account_id, group_id=group.group_id)
+                    self._insert_expt_assignment(assignment)
 
             for recommender in experiment.recommenders:
                 recommender.recommender_id = self._insert_expt_recommender(
@@ -107,7 +107,7 @@ class DbExperimentRepository(DatabaseRepository):
     def fetch_active_expt_assignments(self, date: datetime.date | None = None) -> dict[UUID, Assignment]:
         assignments_tbl = self.tables["expt_assignments"]
 
-        group_ids = self.get_active_expt_group_ids(date)
+        group_ids = self.fetch_active_expt_group_ids(date)
 
         group_query = select(
             assignments_tbl.c.assignment_id, assignments_tbl.c.account_id, assignments_tbl.c.group_id
@@ -122,14 +122,10 @@ class DbExperimentRepository(DatabaseRepository):
 
         return group_lookup_by_account
 
-    get_active_expt_group_ids = fetch_active_expt_group_ids
-    get_active_expt_endpoint_urls = fetch_active_expt_endpoint_urls
-    get_active_expt_allocations = fetch_active_expt_assignments
-
     def update_expt_assignment_to_opt_out(self, account_id: UUID) -> UUID | None:
         assignments_tbl = self.tables["expt_assignments"]
 
-        group_ids = self.get_active_expt_group_ids()
+        group_ids = self.fetch_active_expt_group_ids()
 
         assignment_query = (
             update(assignments_tbl)

--- a/src/poprox_storage/repositories/images.py
+++ b/src/poprox_storage/repositories/images.py
@@ -31,7 +31,7 @@ class DbImageRepository(DatabaseRepository):
 
         for image in images:
             try:
-                image_id = self.insert_image(image)
+                image_id = self.store_image(image)
                 if image_id is None:
                     msg = f"Insert failed for image {image}"
                     raise RuntimeError(msg)
@@ -43,9 +43,6 @@ class DbImageRepository(DatabaseRepository):
 
     def store_image(self, image: Image) -> UUID | None:
         return self._insert_model("images", image, exclude={"image_id"}, constraint="uq_images")
-
-    insert_images = store_images
-    insert_image = store_image
 
     def fetch_image_by_external_id(self, external_id: str) -> Image | None:
         image_table = self.tables["images"]
@@ -121,14 +118,10 @@ class S3ImageRepository(S3Repository):
         images = []
 
         for key in file_keys:
-            extracted = self.get_images_from_file(key)
+            extracted = self.fetch_images_from_file(key)
             images.extend(extracted)
 
         return images
-
-    list_image_files = fetch_image_file_keys
-    get_images_from_file = fetch_images_from_file
-    get_images_from_files = fetch_images_from_files
 
 
 def extract_images(img_file_content) -> list[Image]:

--- a/src/poprox_storage/repositories/newsletters.py
+++ b/src/poprox_storage/repositories/newsletters.py
@@ -77,5 +77,3 @@ class DbNewsletterRepository(DatabaseRepository):
             ]
             historic_newsletters[row.account_id][row.newsletter_id] = articles
         return historic_newsletters
-
-    log_newsletter_content = store_newsletter

--- a/src/poprox_storage/repositories/qualtrics_survey.py
+++ b/src/poprox_storage/repositories/qualtrics_survey.py
@@ -48,8 +48,6 @@ class DbQualtricsSurveyRepository(DatabaseRepository):
             for row in results
         ]
 
-    get_active_surveys = fetch_active_surveys
-
     def update_survey(self, survey: QualtricsSurvey) -> UUID | None:
         survey_table = self.tables["qualtrics_surveys"]
         return self._upsert_and_return_id(
@@ -79,6 +77,3 @@ class DbQualtricsSurveyRepository(DatabaseRepository):
             },
             constraint="uq_qualtrics_response_id",
         )
-
-    create_survey_instance = store_survey_instance
-    create_or_update_survey_response = store_survey_response

--- a/tests/test_clicks.py
+++ b/tests/test_clicks.py
@@ -38,15 +38,15 @@ def test_get_click_between(pg_url: str):
         dbNewsletterRepository = DbNewsletterRepository(conn)
         dbClicksRepository = DbClicksRepository(conn)
 
-        user_account_1 = dbAccountRepository.create_new_account(email="user-1@gmail.com", source="test")
+        user_account_1 = dbAccountRepository.store_new_account(email="user-1@gmail.com", source="test")
 
         articles = [
             Article(title="title-1", url="url-1"),
             Article(title="title-2", url="url-2"),
         ]
 
-        article_id_1 = dbArticleRepository.insert_article(articles[0])
-        article_id_2 = dbArticleRepository.insert_article(articles[1])
+        article_id_1 = dbArticleRepository.store_article(articles[0])
+        article_id_2 = dbArticleRepository.store_article(articles[1])
 
         accounts = [
             Account(account_id=user_account_1.account_id, email="user-1@gmail.com", status="", source="test"),
@@ -54,18 +54,18 @@ def test_get_click_between(pg_url: str):
         ]
 
         newsletter_id = uuid4()
-        dbNewsletterRepository.log_newsletter_content(newsletter_id, user_account_1.account_id, [], "")
+        dbNewsletterRepository.store_newsletter(newsletter_id, user_account_1.account_id, [], "")
 
-        dbClicksRepository.track_click_in_database(
+        dbClicksRepository.store_click(
             newsletter_id, user_account_1.account_id, article_id_1, "title-1", "2024-06-12 09:55:22"
         )
-        dbClicksRepository.track_click_in_database(
+        dbClicksRepository.store_click(
             newsletter_id, user_account_1.account_id, article_id_2, "title-2", "2024-07-14 12:55:22"
         )
 
         start_time = "2024-06-13 09:55:22"
         end_time = "2024-07-15 09:55:22"
-        results = dbClicksRepository.get_clicks_between(accounts, start_time, end_time)
+        results = dbClicksRepository.fetch_clicks_between(accounts, start_time, end_time)
 
         assert 2 == len(results)
 

--- a/tests/test_newsletters.py
+++ b/tests/test_newsletters.py
@@ -45,13 +45,13 @@ def test_fetch_newsletters(pg_url: str):
             Article(title="title-3", url="url-1"),
         ]
 
-        user_account_1 = dbAccountRepository.create_new_account(email="user-1@gmail.com", source="test")
-        user_account_2 = dbAccountRepository.create_new_account(email="user-2@gmail.com", source="test")
+        user_account_1 = dbAccountRepository.store_new_account(email="user-1@gmail.com", source="test")
+        user_account_2 = dbAccountRepository.store_new_account(email="user-2@gmail.com", source="test")
         accounts = [user_account_1, user_account_2]
 
-        article_id_1 = dbArticleRepository.insert_article(newsletter_1_articles[0])
-        article_id_2 = dbArticleRepository.insert_article(newsletter_1_articles[1])
-        article_id_3 = dbArticleRepository.insert_article(newsletter_2_articles[0])
+        article_id_1 = dbArticleRepository.store_article(newsletter_1_articles[0])
+        article_id_2 = dbArticleRepository.store_article(newsletter_1_articles[1])
+        article_id_3 = dbArticleRepository.store_article(newsletter_2_articles[0])
 
         newsletter_1_articles = dbArticleRepository.fetch_articles_by_id([article_id_1, article_id_2])
         newsletter_2_articles = dbArticleRepository.fetch_articles_by_id([article_id_3])
@@ -60,10 +60,10 @@ def test_fetch_newsletters(pg_url: str):
         newsletter_2_id = uuid4()
 
         dbNewsletterRepository.conn.commit()
-        dbNewsletterRepository.log_newsletter_content(
+        dbNewsletterRepository.store_newsletter(
             newsletter_1_id, user_account_1.account_id, newsletter_1_articles, "fake-url-1"
         )
-        dbNewsletterRepository.log_newsletter_content(
+        dbNewsletterRepository.store_newsletter(
             newsletter_2_id, user_account_2.account_id, newsletter_2_articles, "fake-url-2"
         )
 

--- a/tests/test_qualtrics_survey_repository.py
+++ b/tests/test_qualtrics_survey_repository.py
@@ -34,7 +34,7 @@ def test_get_active_survey(pg_url: str):
         conn.commit()
 
         repo = DbQualtricsSurveyRepository(conn)
-        results = repo.get_active_surveys()
+        results = repo.fetch_active_surveys()
         assert 1 == len(results)
 
         survey = results[0]
@@ -53,13 +53,13 @@ def test_update_survey(pg_url: str):
         conn.commit()
 
         repo = DbQualtricsSurveyRepository(conn)
-        results = repo.get_active_surveys()
+        results = repo.fetch_active_surveys()
         survey = results[0]
 
         survey.continuation_token = "apple"
         repo.update_survey(survey)
 
-        results = repo.get_active_surveys()
+        results = repo.fetch_active_surveys()
         assert len(results) == 1
 
         survey = results[0]
@@ -68,7 +68,7 @@ def test_update_survey(pg_url: str):
         assert "apple" == survey.continuation_token
 
 
-def test_create_survey_instance(pg_url: str):
+def test_store_survey_instance(pg_url: str):
     engine = create_engine(pg_url)
     with engine.connect() as conn:
         conn.execute(text("delete from qualtrics_survey_responses;"))
@@ -81,9 +81,9 @@ def test_create_survey_instance(pg_url: str):
         )
 
         repo = DbQualtricsSurveyRepository(conn)
-        results = repo.get_active_surveys()
+        results = repo.fetch_active_surveys()
         survey = results[0]
-        repo.create_survey_instance(survey, uuid)
+        repo.store_survey_instance(survey, uuid)
         results = conn.execute(text("select * from qualtrics_survey_instances;")).fetchall()
         assert 1 == len(results)
         assert survey.survey_id == results[0].survey_id
@@ -106,9 +106,9 @@ def test_create_survey_response(pg_url: str):
         )
 
         repo = DbQualtricsSurveyRepository(conn)
-        results = repo.get_active_surveys()
+        results = repo.fetch_active_surveys()
         survey = results[0]
-        repo.create_survey_instance(survey, account_uuid)
+        repo.store_survey_instance(survey, account_uuid)
         results = conn.execute(text("select * from qualtrics_survey_instances;")).fetchall()
         survey_instance_id = results[0].survey_instance_id
         raw_data = json.loads(
@@ -119,7 +119,7 @@ def test_create_survey_response(pg_url: str):
             qualtrics_response_id="R_1pKcm3b4BQjh6zF",
             raw_data=raw_data,
         )
-        repo.create_or_update_survey_response(survey_response)
+        repo.store_survey_response(survey_response)
         results = conn.execute(text("select * from qualtrics_survey_responses;")).fetchall()
         assert 1 == len(results)
         assert survey_instance_id == results[0].survey_instance_id
@@ -142,9 +142,9 @@ def test_update_survey_response(pg_url: str):
         )
 
         repo = DbQualtricsSurveyRepository(conn)
-        results = repo.get_active_surveys()
+        results = repo.fetch_active_surveys()
         survey = results[0]
-        repo.create_survey_instance(survey, account_uuid)
+        repo.store_survey_instance(survey, account_uuid)
         results = conn.execute(text("select * from qualtrics_survey_instances;")).fetchall()
         survey_instance_id = results[0].survey_instance_id
         raw_data = json.loads(
@@ -155,9 +155,9 @@ def test_update_survey_response(pg_url: str):
             qualtrics_response_id="R_1pKcm3b4BQjh6zF",
             raw_data=raw_data,
         )
-        repo.create_or_update_survey_response(survey_response)
+        repo.store_survey_response(survey_response)
         survey_response.raw_data = {"test": "yay"}
-        repo.create_or_update_survey_response(survey_response)
+        repo.store_survey_response(survey_response)
 
         results = conn.execute(text("select * from qualtrics_survey_responses;")).fetchall()
         assert 1 == len(results)


### PR DESCRIPTION
We put these in for backward compatibility while we updated the other repos which will soon be complete, so we're ready to remove the aliases.