### PR TITLE
Auto-register `DatabaseRepository` sub-classes to create with decorator

### DIFF
--- a/src/poprox_storage/repositories/data_stores/db.py
+++ b/src/poprox_storage/repositories/data_stores/db.py
@@ -48,7 +48,6 @@ class DatabaseRepository:
         Gets called once for each loaded class that sub-classes DatabaseRepository
         """
 
-        # Register the attribute name and corresponding class
         cls._repository_types.add(cls)
 
     def _load_tables(self, *args) -> dict[str, Table]:

--- a/src/poprox_storage/repositories/data_stores/db.py
+++ b/src/poprox_storage/repositories/data_stores/db.py
@@ -1,7 +1,9 @@
 import logging
-from typing import Any
+from functools import wraps
+from typing import Annotated, Any, get_type_hints
 from uuid import UUID
 
+from pydantic import BaseModel, ConfigDict, Field, create_model
 from sqlalchemy import (
     Connection,
     MetaData,
@@ -16,9 +18,66 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 
 
+DbRepositories: type[BaseModel] = create_model(
+    "DbRepositories",
+    conn=(Connection, None),
+    __config__=ConfigDict(arbitrary_types_allowed=True),
+)
+
+
+def camel_to_snake(s):
+    return "".join(["_" + c.lower() if c.isupper() else c for c in s]).lstrip("_")
+
+
+def db_repositories(*args):
+    if len(args) == 1 and not isinstance(args[0], list):
+        names = [args[0]]
+    else:
+        names = args
+
+    def inner_decorator(handler):
+        @wraps(handler)
+        def wrapper(event, context):
+            type_hints = get_type_hints(DbRepositories)
+            with DB_ENGINE.connect() as conn:
+                # create Repositories object and pre-construct all requested repository objects
+                repos = DbRepositories(conn=conn)
+                for name in names:
+                    repo_type = type_hints[name]
+                    setattr(repos, name, repo_type(conn))
+                return handler(event, context, repos)
+
+        return wrapper
+
+    return inner_decorator
+
+
 class DatabaseRepository:
+    _repository_types = {}
+
     def __init__(self, connection: Connection):
         self.conn: Connection = connection
+
+    def __init_subclass__(cls, *args, **kwargs):
+        """
+        Gets called once for each loaded class that sub-classes DatabaseRepository
+        """
+        global DbRepositories
+
+        # Register the attribute name and corresponding class
+        concept_name = camel_to_snake(cls.__name__.removeprefix("Db").removesuffix("Repository"))
+        cls._repository_types[concept_name] = cls
+
+        # Convert the attribute names and classes to fields
+        fields = {name: Annotated[type_, Field(default=None)] for name, type_ in cls._repository_types.items()}
+
+        # Dynamically create a Pydantic model with those fields
+        DbRepositories = create_model(
+            "DbRepositories",
+            conn=(Connection, None),
+            **fields,
+            __config__=ConfigDict(arbitrary_types_allowed=True),
+        )
 
     def _load_tables(self, *args) -> dict[str, Table]:
         metadata = MetaData()

--- a/tests/test_repositories.py
+++ b/tests/test_repositories.py
@@ -1,0 +1,21 @@
+from sqlalchemy import Connection
+
+from poprox_storage.repositories import DbArticleRepository
+from poprox_storage.repositories.data_stores.db import db_repositories
+
+
+@db_repositories("article")
+def example(event, context, repos):
+    return repos
+
+
+def test_repositories():
+    repos = example({}, {})
+    fields = repos.model_fields
+    assert fields != []
+
+    assert "conn" in fields
+    assert fields["conn"].annotation == Connection
+
+    assert "article" in fields
+    assert fields["article"].annotation == DbArticleRepository

--- a/tests/test_repositories.py
+++ b/tests/test_repositories.py
@@ -19,3 +19,5 @@ def test_repositories():
 
     assert "article" in fields
     assert fields["article"].annotation == DbArticleRepository
+
+    assert isinstance(repos.article, DbArticleRepository)


### PR DESCRIPTION
This is the deep dark magic that allows auto-detection of which repository classes are available to be constructed by the decorator.