### PR TITLE
Clean up database test fixtures

### DIFF
--- a/src/poprox_storage/repositories/data_stores/db.py
+++ b/src/poprox_storage/repositories/data_stores/db.py
@@ -10,8 +10,6 @@ from sqlalchemy import (
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.exc import IntegrityError, InternalError
 
-from poprox_storage.aws import DB_ENGINE
-
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 
@@ -24,7 +22,7 @@ class DatabaseRepository:
         metadata = MetaData()
         tables = {}
         for table_name in args:
-            tables[table_name] = Table(table_name, metadata, autoload_with=DB_ENGINE)
+            tables[table_name] = Table(table_name, metadata, autoload_with=self.conn.engine)
         return tables
 
     def _id_query(self, query):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,22 @@
+import os
+
+import pytest
+from sqlalchemy import create_engine
+
+db_password = os.environ.get("POPROX_DB_PASSWORD", "")
+db_port = os.environ.get("POPROX_DB_PORT", "5433")
+
+DEFAULT_PG_URL = f"postgresql://postgres:{db_password}@127.0.0.1:{db_port}/poprox"
+
+
+@pytest.fixture(scope="session")
+def pg_url():
+    """
+    Provides base PostgreSQL URL for creating temporary databases.
+    """
+    return os.getenv("CI_POPROX_PG_URL", DEFAULT_PG_URL)
+
+
+@pytest.fixture(scope="session")
+def db_engine(pg_url):
+    return create_engine(pg_url)

--- a/tests/test_clicks.py
+++ b/tests/test_clicks.py
@@ -1,8 +1,6 @@
-import os
 from uuid import uuid4
 
-import pytest
-from sqlalchemy import create_engine, text
+from sqlalchemy import text
 
 from poprox_concepts import Account, Article
 from poprox_storage.repositories.accounts import DbAccountRepository
@@ -10,23 +8,9 @@ from poprox_storage.repositories.articles import DbArticleRepository
 from poprox_storage.repositories.clicks import DbClicksRepository
 from poprox_storage.repositories.newsletters import DbNewsletterRepository
 
-db_password = os.environ.get("POPROX_DB_PASSWORD", "")
-db_port = os.environ.get("POPROX_DB_PORT", "")
 
-DEFAULT_PG_URL = f"postgresql://postgres:{db_password}@127.0.0.1:{db_port}/poprox"
-
-
-@pytest.fixture(scope="session")
-def pg_url():
-    """
-    Provides base PostgreSQL URL for creating temporary databases.
-    """
-    return os.getenv("CI_POPROX_PG_URL", DEFAULT_PG_URL)
-
-
-def test_get_click_between(pg_url: str):
-    engine = create_engine(pg_url)
-    with engine.connect() as conn:
+def test_get_click_between(db_engine):
+    with db_engine.connect() as conn:
         conn.execute(text("delete from impressions"))
         conn.execute(text("delete from clicks;"))
         conn.execute(text("delete from newsletters;"))

--- a/tests/test_newsletters.py
+++ b/tests/test_newsletters.py
@@ -1,31 +1,15 @@
-import os
 from uuid import uuid4
 
-import pytest
-from sqlalchemy import create_engine, text
+from sqlalchemy import text
 
 from poprox_concepts import Article
 from poprox_storage.repositories.accounts import DbAccountRepository
 from poprox_storage.repositories.articles import DbArticleRepository
 from poprox_storage.repositories.newsletters import DbNewsletterRepository
 
-db_password = os.environ.get("POPROX_DB_PASSWORD", "")
-db_port = os.environ.get("POPROX_DB_PORT", "")
 
-DEFAULT_PG_URL = f"postgresql://postgres:{db_password}@127.0.0.1:{db_port}/poprox"
-
-
-@pytest.fixture(scope="session")
-def pg_url():
-    """
-    Provides base PostgreSQL URL for creating temporary databases.
-    """
-    return os.getenv("CI_POPROX_PG_URL", DEFAULT_PG_URL)
-
-
-def test_fetch_newsletters(pg_url: str):
-    engine = create_engine(pg_url)
-    with engine.connect() as conn:
+def test_fetch_newsletters(db_engine):
+    with db_engine.connect() as conn:
         conn.execute(text("delete from impressions"))
         conn.execute(text("delete from clicks;"))
         conn.execute(text("delete from newsletters;"))

--- a/tests/test_qualtrics_survey_repository.py
+++ b/tests/test_qualtrics_survey_repository.py
@@ -1,30 +1,14 @@
 import json
-import os
 from uuid import uuid4
 
-import pytest
-from sqlalchemy import create_engine, text
+from sqlalchemy import text
 
 from poprox_storage.concepts.qualtrics_survey import QualtricsSurveyResponse
 from poprox_storage.repositories.qualtrics_survey import DbQualtricsSurveyRepository
 
-db_password = os.environ.get("POPROX_DB_PASSWORD", "")
-db_port = os.environ.get("POPROX_DB_PORT", "")
 
-DEFAULT_PG_URL = f"postgresql://postgres:{db_password}@127.0.0.1:{db_port}/poprox"
-
-
-@pytest.fixture(scope="session")
-def pg_url():
-    """
-    Provides base PostgreSQL URL for creating temporary databases.
-    """
-    return os.getenv("CI_POPROX_PG_URL", DEFAULT_PG_URL)
-
-
-def test_get_active_survey(pg_url: str):
-    engine = create_engine(pg_url)
-    with engine.connect() as conn:
+def test_get_active_survey(db_engine):
+    with db_engine.connect() as conn:
         conn.execute(text("delete from qualtrics_survey_responses;"))
         conn.execute(text("delete from qualtrics_survey_instances;"))
         conn.execute(text("delete from qualtrics_surveys;"))
@@ -44,9 +28,8 @@ def test_get_active_survey(pg_url: str):
         assert None is survey.continuation_token
 
 
-def test_update_survey(pg_url: str):
-    engine = create_engine(pg_url)
-    with engine.connect() as conn:
+def test_update_survey(db_engine):
+    with db_engine.connect() as conn:
         conn.execute(text("delete from qualtrics_survey_responses;"))
         conn.execute(text("delete from qualtrics_survey_instances;"))
         conn.execute(text("delete from qualtrics_surveys;"))
@@ -69,9 +52,8 @@ def test_update_survey(pg_url: str):
         assert "apple" == survey.continuation_token
 
 
-def test_store_survey_instance(pg_url: str):
-    engine = create_engine(pg_url)
-    with engine.connect() as conn:
+def test_store_survey_instance(db_engine):
+    with db_engine.connect() as conn:
         conn.execute(text("delete from qualtrics_survey_responses;"))
         conn.execute(text("delete from qualtrics_survey_instances;"))
         conn.execute(text("delete from qualtrics_surveys;"))
@@ -92,9 +74,8 @@ def test_store_survey_instance(pg_url: str):
         assert None is not results[0].survey_instance_id
 
 
-def test_create_survey_response(pg_url: str):
-    engine = create_engine(pg_url)
-    with engine.connect() as conn:
+def test_create_survey_response(db_engine):
+    with db_engine.connect() as conn:
         conn.execute(text("delete from qualtrics_survey_responses;"))
         conn.execute(text("delete from qualtrics_survey_instances;"))
         conn.execute(text("delete from qualtrics_surveys;"))
@@ -128,9 +109,8 @@ def test_create_survey_response(pg_url: str):
         assert raw_data == results[0].raw_data
 
 
-def test_update_survey_response(pg_url: str):
-    engine = create_engine(pg_url)
-    with engine.connect() as conn:
+def test_update_survey_response(db_engine):
+    with db_engine.connect() as conn:
         conn.execute(text("delete from qualtrics_survey_responses;"))
         conn.execute(text("delete from qualtrics_survey_instances;"))
         conn.execute(text("delete from qualtrics_surveys;"))


### PR DESCRIPTION
In order to work seamlessly with a local database, we also need to use the same database engine that the connection was created from. Otherwise we run the risk of e.g. connecting to the prod database and running a bunch of delete statements.