### PR TITLE
Rename article `title` and `content` to `headline` and `subhead`

### DIFF
--- a/poprox-db/migrations/versions/2024_08_21_1418-dd50d8e7777e_rename_article_headline_and_subhead.py
+++ b/poprox-db/migrations/versions/2024_08_21_1418-dd50d8e7777e_rename_article_headline_and_subhead.py
@@ -1,0 +1,27 @@
+"""rename article headline and subhead
+
+Revision ID: dd50d8e7777e
+Revises: db45222a34e2
+Create Date: 2024-08-21 14:18:35.334126
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "dd50d8e7777e"
+down_revision: Union[str, None] = "db45222a34e2"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.alter_column("articles", "title", new_column_name="headline")
+    op.alter_column("articles", "content", new_column_name="subhead")
+
+
+def downgrade() -> None:
+    op.alter_column("articles", "headline", new_column_name="title")
+    op.alter_column("articles", "subhead", new_column_name="content")

--- a/src/poprox_storage/repositories/articles.py
+++ b/src/poprox_storage/repositories/articles.py
@@ -205,8 +205,8 @@ class DbArticleRepository(DatabaseRepository):
         return [
             Article(
                 article_id=row.article_id,
-                title=row.title,
-                content=row.content,
+                headline=row.headline,
+                subhead=row.subhead,
                 url=row.url,
                 preview_image_id=row.preview_image_id,
                 published_at=row.published_at,
@@ -268,8 +268,8 @@ class S3ArticleRepository(S3Repository):
         raw_articles = json.loads(response)
         articles = [
             Article(
-                title=raw["title"],
-                content=raw.get("description", None),
+                headline=raw["title"],
+                subhead=raw.get("description", None),
                 url=raw["url"],
                 published_at=datetime.strptime(
                     raw.get("published_time", "1970-01-01T00:00:00")[:19],
@@ -318,8 +318,8 @@ def create_ap_article(ap_item):
     item_id = ap_item.get("altids", {}).get("itemid", None)
 
     ap_item = Article(
-        title=ap_item["headline"],
-        content=ap_item["headline_extended"],
+        headline=ap_item["headline"],
+        subhead=ap_item["headline_extended"],
         url=canonical_link or None,
         published_at=ap_item["firstcreated"],
         mentions=mentions,

--- a/src/poprox_storage/repositories/newsletters.py
+++ b/src/poprox_storage/repositories/newsletters.py
@@ -10,7 +10,7 @@ from sqlalchemy import (
     select,
 )
 
-from poprox_concepts import Account, Article, Newsletter
+from poprox_concepts.domain import Account, Article, Newsletter
 from poprox_storage.repositories.data_stores.db import DatabaseRepository
 
 
@@ -66,8 +66,8 @@ class DbNewsletterRepository(DatabaseRepository):
             articles = [
                 Article(
                     article_id=raw["article_id"],
-                    title=raw["title"],
-                    content=raw.get("content", None),
+                    headline=raw["headline"],
+                    subhead=raw.get("subhead", None),
                     url=raw["url"],
                     published_at=datetime.strptime(
                         raw.get("published_at", "1970-01-01T00:00:00")[:19],

--- a/tests/test_clicks.py
+++ b/tests/test_clicks.py
@@ -25,8 +25,8 @@ def test_get_click_between(db_engine):
         user_account_1 = dbAccountRepository.store_new_account(email="user-1@gmail.com", source="test")
 
         articles = [
-            Article(title="title-1", url="url-1"),
-            Article(title="title-2", url="url-2"),
+            Article(headline="headline-1", url="url-1"),
+            Article(headline="headline-2", url="url-2"),
         ]
 
         article_id_1 = dbArticleRepository.store_article(articles[0])
@@ -41,10 +41,10 @@ def test_get_click_between(db_engine):
         dbNewsletterRepository.store_newsletter(newsletter)
 
         dbClicksRepository.store_click(
-            newsletter.newsletter_id, user_account_1.account_id, article_id_1, "title-1", "2024-06-12 09:55:22"
+            newsletter.newsletter_id, user_account_1.account_id, article_id_1, "headline-1", "2024-06-12 09:55:22"
         )
         dbClicksRepository.store_click(
-            newsletter.newsletter_id, user_account_1.account_id, article_id_2, "title-2", "2024-07-14 12:55:22"
+            newsletter.newsletter_id, user_account_1.account_id, article_id_2, "headline-2", "2024-07-14 12:55:22"
         )
 
         start_time = "2024-06-13 09:55:22"

--- a/tests/test_newsletters.py
+++ b/tests/test_newsletters.py
@@ -20,13 +20,27 @@ def test_fetch_newsletters(db_engine):
 
         newsletter_1_articles = [
             Article(
-                title="title-1", content="article content 1", url="url-1", external_id="external-1", source="tests"
+                headline="headline-1",
+                subhead="subhead-1",
+                url="url-1",
+                external_id="external-1",
+                source="tests",
             ),
-            Article(title="title-2", url="url-2", external_id="external-2", source="tests"),
+            Article(
+                headline="headline-2",
+                url="url-2",
+                external_id="external-2",
+                source="tests",
+            ),
         ]
 
         newsletter_2_articles = [
-            Article(title="title-3", url="url-1", external_id="external-3", source="tests"),
+            Article(
+                headline="headline-3",
+                url="url-1",
+                external_id="external-3",
+                source="tests",
+            ),
         ]
 
         user_account_1 = dbAccountRepository.store_new_account(email="user-1@gmail.com", source="test")
@@ -61,7 +75,7 @@ def test_fetch_newsletters(db_engine):
         user_1_newsletter = results[user_account_1.account_id]
         assert 1 == len(user_1_newsletter)
         assert 2 == len(user_1_newsletter[newsletter_1.newsletter_id])
-        assert "article content 1" == user_1_newsletter[newsletter_1.newsletter_id][0].content
+        assert "subhead-1" == user_1_newsletter[newsletter_1.newsletter_id][0].subhead
 
         user_2_newsletter = results[user_account_2.account_id]
         assert 1 == len(user_2_newsletter)


### PR DESCRIPTION
These names probably originated with the early articles we scraped directly from AP's website, which were stored with different field names than are commonly used in journalism. Journalists sometimes call these the `hed` and `subhed`/`dek`, so I've adapted those names a bit to be easier for us to use while staying as true to the source domain as I can.

This differentiates the `subhead` (formerly `content`) from the actual text of the article, which we may soon start fetching from AP with additional API calls.

Connected PRs:
* https://github.com/CCRI-POPROX/poprox-concepts/pull/22
* https://github.com/CCRI-POPROX/poprox-storage/pull/40
* https://github.com/CCRI-POPROX/poprox-platform/pull/142
* https://github.com/CCRI-POPROX/poprox-recommender/pull/91