### PR TITLE
Fix experiment manifest ingestion

### DIFF
--- a/src/poprox_storage/concepts/experiment.py
+++ b/src/poprox_storage/concepts/experiment.py
@@ -1,19 +1,19 @@
 from __future__ import annotations
 
 from datetime import date, timedelta
-from uuid import UUID
+from uuid import UUID, uuid4
 
-from pydantic import BaseModel, PositiveInt
+from pydantic import BaseModel, Field, PositiveInt
 
 
 class Team(BaseModel):
-    team_id: UUID | None = None
+    team_id: UUID = Field(default_factory=uuid4)
     team_name: str
     members: list[UUID]
 
 
 class Experiment(BaseModel):
-    experiment_id: UUID | None = None
+    experiment_id: UUID = Field(default_factory=uuid4)
     owner: Team
     description: str
     start_date: date
@@ -67,19 +67,19 @@ class Treatment(BaseModel):
 
 
 class Group(BaseModel):
-    group_id: UUID | None = None
+    group_id: UUID = Field(default_factory=uuid4)
     name: str
     minimum_size: PositiveInt
 
 
 class Recommender(BaseModel):
-    recommender_id: UUID | None = None
+    recommender_id: UUID = Field(default_factory=uuid4)
     name: str
     endpoint_url: str
 
 
 class Phase(BaseModel):
-    phase_id: UUID | None = None
+    phase_id: UUID = Field(default_factory=uuid4)
     name: str
     start_date: date
     end_date: date
@@ -91,7 +91,7 @@ class Phase(BaseModel):
 
 
 class Assignment(BaseModel):
-    assignment_id: UUID | None = None
+    assignment_id: UUID = Field(default_factory=uuid4)
     account_id: UUID
     group_id: UUID
-    opted_out: bool | None = None
+    opted_out: bool = Field(default=False)

--- a/src/poprox_storage/repositories/accounts.py
+++ b/src/poprox_storage/repositories/accounts.py
@@ -35,22 +35,46 @@ class DbAccountRepository(DatabaseRepository):
     def fetch_accounts(self, account_ids: list[UUID] | None = None) -> list[Account]:
         account_tbl = self.tables["accounts"]
 
-        query = select(account_tbl.c.account_id, account_tbl.c.email, account_tbl.c.status)
+        query = select(
+            account_tbl.c.account_id,
+            account_tbl.c.email,
+            account_tbl.c.status,
+            account_tbl.c.source,
+        )
         if account_ids is not None:
             query = query.where(account_tbl.c.account_id.in_(account_ids))
         elif len(account_ids) == 0:
             return []
         result = self.conn.execute(query).fetchall()
 
-        return [Account(account_id=rec.account_id, email=rec.email, status=rec.status) for rec in result]
+        return [
+            Account(
+                account_id=row.account_id,
+                email=row.email,
+                status=row.status,
+                source=row.source,
+            )
+            for row in result
+        ]
 
     def fetch_account_by_email(self, email: str) -> Account | None:
         account_tbl = self.tables["accounts"]
-        query = sqlalchemy.select(account_tbl.c.account_id, account_tbl.c.email, account_tbl.c.status).where(
-            account_tbl.c.email == email
-        )
+        query = sqlalchemy.select(
+            account_tbl.c.account_id,
+            account_tbl.c.email,
+            account_tbl.c.status,
+            account_tbl.c.source,
+        ).where(account_tbl.c.email == email)
         result = self.conn.execute(query).fetchall()
-        accounts = [Account(account_id=row.account_id, email=row.email, status=row.status) for row in result]
+        accounts = [
+            Account(
+                account_id=row.account_id,
+                email=row.email,
+                status=row.status,
+                source=row.source,
+            )
+            for row in result
+        ]
         if len(accounts) > 0:
             return accounts[0]
         return None


### PR DESCRIPTION
This does two things:
* Auto-assigns UUIDs when creating experiment-related domain classes
* Includes the recruitment source when fetching accounts (which is important for determining eligibility)