### PR TITLE
Replace recommender `endpoint` with `url` in manifest and methods

### DIFF
--- a/src/poprox_storage/concepts/experiment.py
+++ b/src/poprox_storage/concepts/experiment.py
@@ -75,7 +75,7 @@ class Group(BaseModel):
 class Recommender(BaseModel):
     recommender_id: UUID = Field(default_factory=uuid4)
     name: str
-    endpoint_url: str
+    url: str
 
 
 class Phase(BaseModel):

--- a/src/poprox_storage/concepts/manifest.py
+++ b/src/poprox_storage/concepts/manifest.py
@@ -110,7 +110,7 @@ def manifest_to_experiment(manifest: ManifestFile) -> Experiment:
     )
 
     recommenders = {
-        rec_name: Recommender(recommender_id=uuid4(), name=rec_name, url=recommender.endpoint)
+        rec_name: Recommender(recommender_id=uuid4(), name=rec_name, url=recommender.url)
         for rec_name, recommender in manifest.recommenders.items()
     }
 

--- a/src/poprox_storage/concepts/manifest.py
+++ b/src/poprox_storage/concepts/manifest.py
@@ -58,7 +58,7 @@ class ManifestPhaseAssignment(BaseModel):
 
 
 class ManifestRecommender(BaseModel):
-    endpoint: str
+    url: str
 
 
 class ManifestGroupSpec(BaseModel):
@@ -110,7 +110,7 @@ def manifest_to_experiment(manifest: ManifestFile) -> Experiment:
     )
 
     recommenders = {
-        rec_name: Recommender(recommender_id=uuid4(), name=rec_name, endpoint_url=recommender.endpoint)
+        rec_name: Recommender(recommender_id=uuid4(), name=rec_name, url=recommender.endpoint)
         for rec_name, recommender in manifest.recommenders.items()
     }
 

--- a/src/poprox_storage/repositories/experiments.py
+++ b/src/poprox_storage/repositories/experiments.py
@@ -110,7 +110,7 @@ class DbExperimentRepository(DatabaseRepository):
 
         return treatment_lookup_by_group
 
-    def fetch_treatment_endpoint_urls(self, treatment_ids: list[UUID]) -> dict[UUID, str]:
+    def fetch_treatment_recommender_urls(self, treatment_ids: list[UUID]) -> dict[UUID, str]:
         recommenders_tbl = self.tables["expt_recommenders"]
         treatments_tbl = self.tables["expt_treatments"]
 
@@ -128,7 +128,7 @@ class DbExperimentRepository(DatabaseRepository):
 
         return endpoints_by_treatment
 
-    def fetch_active_expt_endpoint_urls(self, date: datetime.date | None = None) -> dict[UUID, str]:
+    def fetch_active_expt_recommender_urls(self, date: datetime.date | None = None) -> dict[UUID, str]:
         groups_tbl = self.tables["expt_groups"]
         phases_tbl = self.tables["expt_phases"]
         recommenders_tbl = self.tables["expt_recommenders"]

--- a/src/poprox_storage/repositories/experiments.py
+++ b/src/poprox_storage/repositories/experiments.py
@@ -291,8 +291,9 @@ class DbExperimentRepository(DatabaseRepository):
             {
                 "recommender_name": recommender.name,
                 "experiment_id": experiment_id,
+                "endpoint_url": recommender.url,
             },
-            exclude={"name"},
+            exclude={"name", "url"},
             commit=False,
         )
 

--- a/tests/data/sample_manifest.toml
+++ b/tests/data/sample_manifest.toml
@@ -20,13 +20,13 @@ identical_to = "b"
 
 
 [recommenders.x]
-endpoint = "https://example.com/recommender_x"
+url = "https://example.com/recommender_x"
 
 [recommenders.y]
-endpoint = "https://example.com/recommender_y"
+url = "https://example.com/recommender_y"
 
 [recommenders.z]
-endpoint = "https://example.com/recommender_z"
+url = "https://example.com/recommender_z"
 
 [phases]
 sequence = ["1", "2", "3"]


### PR DESCRIPTION
This should help us disambiguate "endpoint" to mean "HTTP endpoint," which corresponds to a single Lambda. 