### PR TITLE
Query and export the relevant data for experiment dataset exports

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ authors = [{ name = "Karl Higley", email = "khigley@umn.edu" }]
 dependencies = [
   "boto3~=1.33.3",
   "botocore~=1.33.3",
+  "pandas",
   "psycopg2-binary",
   "pydantic~=2.7.1",
   "smart_open",

--- a/src/poprox_storage/concepts/experiment.py
+++ b/src/poprox_storage/concepts/experiment.py
@@ -14,7 +14,7 @@ class Team(BaseModel):
 
 class Experiment(BaseModel):
     experiment_id: UUID = Field(default_factory=uuid4)
-    owner: Team
+    owner: Team | None = None
     description: str
     start_date: date
     end_date: date

--- a/src/poprox_storage/concepts/experiment.py
+++ b/src/poprox_storage/concepts/experiment.py
@@ -62,6 +62,7 @@ class Experiment(BaseModel):
 
 
 class Treatment(BaseModel):
+    treatment_id: UUID = Field(default_factory=uuid4)
     group: Group
     recommender: Recommender
 

--- a/src/poprox_storage/repositories/__init__.py
+++ b/src/poprox_storage/repositories/__init__.py
@@ -11,7 +11,9 @@ from poprox_storage.repositories.experiments import (
     S3ExperimentRepository,
 )
 from poprox_storage.repositories.images import DbImageRepository, S3ImageRepository
-from poprox_storage.repositories.newsletters import DbNewsletterRepository
+from poprox_storage.repositories.newsletters import DbNewsletterRepository, S3NewsletterRepository
+from poprox_storage.repositories.placements import DbPlacementRepository
+from poprox_storage.repositories.qualtrics_survey import DbQualtricsSurveyRepository
 
 
 def inject_repos(handler):
@@ -44,16 +46,19 @@ def inject_repos(handler):
 
 
 __all__ = [
-    "DbAccountRepository",
     "DbAccountInterestRepository",
+    "DbAccountRepository",
     "DbArticleRepository",
     "DbClicksRepository",
+    "DbDemographicsRepository",
     "DbExperimentRepository",
     "DbImageRepository",
     "DbNewsletterRepository",
-    "DbDemographicsRepository",
+    "DbPlacementRepository",
+    "DbQualtricsSurveyRepository",
     "S3ArticleRepository",
     "S3ClicksRepository",
     "S3ExperimentRepository",
     "S3ImageRepository",
+    "S3NewsletterRepository",
 ]

--- a/src/poprox_storage/repositories/__init__.py
+++ b/src/poprox_storage/repositories/__init__.py
@@ -13,6 +13,36 @@ from poprox_storage.repositories.experiments import (
 from poprox_storage.repositories.images import DbImageRepository, S3ImageRepository
 from poprox_storage.repositories.newsletters import DbNewsletterRepository
 
+
+def inject_repos(handler):
+    from functools import wraps
+    from typing import get_type_hints
+
+    from poprox_storage.aws import DB_ENGINE
+    from poprox_storage.repositories.data_stores.db import DatabaseRepository
+    from poprox_storage.repositories.data_stores.s3 import S3Repository
+
+    @wraps(handler)
+    def wrapper(event, context):
+        params: dict[str, type] = get_type_hints(handler)
+        # remove event, context, and return type if they were annotated.
+        params.pop("event", None)
+        params.pop("context", None)
+        params.pop("return", None)
+
+        with DB_ENGINE.connect() as conn:
+            repos = dict()
+            for param, class_obj in params.items():
+                if class_obj in DatabaseRepository._repository_types:
+                    repos[param] = class_obj(conn)
+                elif class_obj in S3Repository._repository_types:
+                    repos[param] = class_obj(conn)
+
+            return handler(event, context, **repos)
+
+    return wrapper
+
+
 __all__ = [
     "DbAccountRepository",
     "DbAccountInterestRepository",

--- a/src/poprox_storage/repositories/articles.py
+++ b/src/poprox_storage/repositories/articles.py
@@ -281,6 +281,12 @@ class S3ArticleRepository(S3Repository):
 
         return articles
 
+    def store_articles_as_parquet(self, articles: list[Article], bucket_name: str, file_prefix: str):
+        import pandas as pd
+
+        dataframe = pd.DataFrame.from_records(extract_and_flatten(articles))
+        return self._write_dataframe_as_parquet(dataframe)
+
 
 def extract_articles(news_file_content) -> list[Article]:
     lines = news_file_content.splitlines()
@@ -345,3 +351,25 @@ def create_ap_subject_mention(subject) -> Mention:
     mention = Mention(source=source, relevance=relevance, entity=entity)
 
     return mention
+
+
+def extract_and_flatten(articles):
+    def flatten(article):
+        result = article.__dict__
+        result["article_id"] = str(result["article_id"])
+        mentions = result["mentions"]
+        del result["mentions"]
+        del result["preview_image_id"]
+        del result["source"]
+        del result["external_id"]
+        mention_dict = {}
+        for mention in mentions:
+            key = mention.entity.entity_type + "_" + mention.entity.name
+            if key not in mention_dict or (key in mention_dict and mention.source == "AP-Editorial"):
+                mention_dict[key] = mention
+        result["mentions"] = {}
+        for key, value in mention_dict.items():
+            result["mentions"][key] = value.relevance
+        return result
+
+    return [flatten(article) for article in articles]

--- a/src/poprox_storage/repositories/articles.py
+++ b/src/poprox_storage/repositories/articles.py
@@ -66,6 +66,16 @@ class DbArticleRepository(DatabaseRepository):
             article_table.c.created_at < cutoff,
         )
 
+    def fetch_articles_ingested_between(self, start_date, end_date) -> list[Article]:
+        article_table = self.tables["articles"]
+        return self._get_articles(
+            article_table,
+            and_(
+                article_table.c.created_at <= end_date,
+                article_table.c.created_at >= start_date,
+            ),
+        )
+
     def fetch_articles_by_id(self, ids: list[UUID]) -> list[Article]:
         article_table = self.tables["articles"]
         return self._get_articles(article_table, article_table.c.article_id.in_(ids))

--- a/src/poprox_storage/repositories/articles.py
+++ b/src/poprox_storage/repositories/articles.py
@@ -291,11 +291,11 @@ class S3ArticleRepository(S3Repository):
 
         return articles
 
-    def store_articles_as_parquet(self, articles: list[Article], bucket_name: str, file_prefix: str):
+    def store_as_parquet(self, articles: list[Article], bucket_name: str, file_prefix: str):
         import pandas as pd
 
         dataframe = pd.DataFrame.from_records(extract_and_flatten(articles))
-        return self._write_dataframe_as_parquet(dataframe)
+        return self._write_dataframe_as_parquet(dataframe, bucket_name, file_prefix)
 
 
 def extract_articles(news_file_content) -> list[Article]:

--- a/src/poprox_storage/repositories/articles.py
+++ b/src/poprox_storage/repositories/articles.py
@@ -291,11 +291,17 @@ class S3ArticleRepository(S3Repository):
 
         return articles
 
-    def store_as_parquet(self, articles: list[Article], bucket_name: str, file_prefix: str):
+    def store_as_parquet(
+        self,
+        articles: list[Article],
+        bucket_name: str,
+        file_prefix: str,
+        start_time: datetime = None,
+    ):
         import pandas as pd
 
         dataframe = pd.DataFrame.from_records(extract_and_flatten(articles))
-        return self._write_dataframe_as_parquet(dataframe, bucket_name, file_prefix)
+        return self._write_dataframe_as_parquet(dataframe, bucket_name, file_prefix, start_time)
 
 
 def extract_articles(news_file_content) -> list[Article]:

--- a/src/poprox_storage/repositories/clicks.py
+++ b/src/poprox_storage/repositories/clicks.py
@@ -131,19 +131,15 @@ class DbClicksRepository(DatabaseRepository):
         ]
 
 
-def extract_and_flatten(clicks):
-    def flatten(account_id, account_clicks):
-        click_list = []
-        for click in account_clicks:
-            row = click.__dict__
-            row["account_id"] = str(account_id)
-            row["article_id"] = str(row["article_id"])
-            row["newsletter_id"] = str(row["newsletter_id"])
-            row["timestamp"] = str(row["timestamp"])
-            click_list.append(row)
-        return click_list
+def extract_and_flatten(clicks: list[Click]) -> list[dict]:
+    def flatten(click: Click):
+        row = click.__dict__
+        row["article_id"] = str(row["article_id"])
+        row["newsletter_id"] = str(row["newsletter_id"])
+        row["timestamp"] = str(row["timestamp"])
+        return row
 
     final_list = []
-    for account_id in clicks:
-        final_list.extend(flatten(account_id, clicks[account_id]))
+    for click in clicks:
+        final_list.extend(flatten(click))
     return final_list

--- a/src/poprox_storage/repositories/clicks.py
+++ b/src/poprox_storage/repositories/clicks.py
@@ -1,6 +1,7 @@
 import json
 import logging
 from collections import defaultdict
+from datetime import datetime
 from uuid import UUID
 
 from sqlalchemy import and_, insert, select
@@ -28,11 +29,17 @@ class S3ClicksRepository(S3Repository):
 
         return click_data
 
-    def store_as_parquet(self, clicks: list[Click], bucket_name: str, file_prefix: str):
+    def store_as_parquet(
+        self,
+        clicks: list[Click],
+        bucket_name: str,
+        file_prefix: str,
+        start_time: datetime = None,
+    ):
         import pandas as pd
 
         dataframe = pd.DataFrame.from_records(extract_and_flatten(clicks))
-        return self._write_dataframe_as_parquet(dataframe, bucket_name, file_prefix)
+        return self._write_dataframe_as_parquet(dataframe, bucket_name, file_prefix, start_time)
 
 
 class DbClicksRepository(DatabaseRepository):

--- a/src/poprox_storage/repositories/clicks.py
+++ b/src/poprox_storage/repositories/clicks.py
@@ -115,6 +115,21 @@ class DbClicksRepository(DatabaseRepository):
 
         return clicked_articles
 
+    def fetch_clicks_by_newsletter_id(self, newsletter_ids: list[UUID]) -> list[Click]:
+        click_table = self.tables["clicks"]
+
+        click_query = select(click_table).where(click_table.c.newsletter_id.in_(newsletter_ids))
+        result = self.conn.execute(click_query).fetchall()
+
+        return [
+            Click(
+                article_id=row.article_id,
+                newsletter_id=row.newsletter_id,
+                timestamp=row.created_at,
+            )
+            for row in result
+        ]
+
 
 def extract_and_flatten(clicks):
     def flatten(account_id, account_clicks):

--- a/src/poprox_storage/repositories/clicks.py
+++ b/src/poprox_storage/repositories/clicks.py
@@ -32,7 +32,7 @@ class S3ClicksRepository(S3Repository):
         import pandas as pd
 
         dataframe = pd.DataFrame.from_records(extract_and_flatten(clicks))
-        return self._write_dataframe_as_parquet(dataframe)
+        return self._write_dataframe_as_parquet(dataframe, bucket_name, file_prefix)
 
 
 class DbClicksRepository(DatabaseRepository):

--- a/src/poprox_storage/repositories/clicks.py
+++ b/src/poprox_storage/repositories/clicks.py
@@ -133,13 +133,14 @@ class DbClicksRepository(DatabaseRepository):
 
 def extract_and_flatten(clicks: list[Click]) -> list[dict]:
     def flatten(click: Click):
-        row = click.__dict__
-        row["article_id"] = str(row["article_id"])
-        row["newsletter_id"] = str(row["newsletter_id"])
-        row["timestamp"] = str(row["timestamp"])
+        row = {}
+        row["newsletter_id"] = str(click.newsletter_id)
+        row["article_id"] = str(click.article_id)
+        row["timestamp"] = click.timestamp
         return row
 
     final_list = []
     for click in clicks:
-        final_list.extend(flatten(click))
+        final_list.append(flatten(click))
+
     return final_list

--- a/src/poprox_storage/repositories/clicks.py
+++ b/src/poprox_storage/repositories/clicks.py
@@ -115,7 +115,7 @@ class DbClicksRepository(DatabaseRepository):
 
         return clicked_articles
 
-    def fetch_clicks_by_newsletter_id(self, newsletter_ids: list[UUID]) -> list[Click]:
+    def fetch_clicks_by_newsletter_ids(self, newsletter_ids: list[UUID]) -> list[Click]:
         click_table = self.tables["clicks"]
 
         click_query = select(click_table).where(click_table.c.newsletter_id.in_(newsletter_ids))

--- a/src/poprox_storage/repositories/data_stores/db.py
+++ b/src/poprox_storage/repositories/data_stores/db.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 
 
-def inject_repos(handler):
+def inject_db_repos(handler):
     @wraps(handler)
     def wrapper(event, context):
         with DB_ENGINE.connect() as conn:

--- a/src/poprox_storage/repositories/data_stores/s3.py
+++ b/src/poprox_storage/repositories/data_stores/s3.py
@@ -45,7 +45,13 @@ class S3Repository:
         with smart_open(load_path, "r") as f:
             return f.read()
 
-    def _write_dataframe_as_parquet(self, dataframe: pd.DataFrame, bucket_name: str, file_prefix: str):
+    def _write_dataframe_as_parquet(
+        self,
+        dataframe: pd.DataFrame,
+        bucket_name: str,
+        file_prefix: str,
+        start_time: datetime = None,
+    ):
         # Export dataframe as Parquet
         # https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.to_parquet.html
         data = BytesIO()
@@ -54,7 +60,7 @@ class S3Repository:
         # reset the BytesIO for reading
         data.seek(0)
 
-        start_time = datetime.now()
+        start_time = start_time or datetime.now()
         file_name = f"{file_prefix}_{start_time.strftime('%Y%m%d-%H%M%S')}.parquet"
 
         with smart_open(f"s3://{bucket_name}/{file_name}", "wb") as out_file:

--- a/src/poprox_storage/repositories/data_stores/s3.py
+++ b/src/poprox_storage/repositories/data_stores/s3.py
@@ -45,7 +45,7 @@ class S3Repository:
         with smart_open(load_path, "r") as f:
             return f.read()
 
-    def _write_dataframe_as_parquet(dataframe: pd.DataFrame, bucket_name: str, file_prefix: str):
+    def _write_dataframe_as_parquet(self, dataframe: pd.DataFrame, bucket_name: str, file_prefix: str):
         # Export dataframe as Parquet
         # https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.to_parquet.html
         data = BytesIO()
@@ -57,7 +57,7 @@ class S3Repository:
         start_time = datetime.now()
         file_name = f"{file_prefix}_{start_time.strftime('%Y%m%d-%H%M%S')}.parquet"
 
-        with open("s3://{bucket_name}/{file_name}", "w") as out_file:
-            out_file.write(data)
+        with smart_open(f"s3://{bucket_name}/{file_name}", "wb") as out_file:
+            out_file.write(data.read())
 
         return file_name

--- a/src/poprox_storage/repositories/data_stores/s3.py
+++ b/src/poprox_storage/repositories/data_stores/s3.py
@@ -1,9 +1,38 @@
+from functools import wraps
+from typing import get_type_hints
+
 from smart_open import open as smart_open
+
+
+def inject_s3_repos(handler):
+    @wraps(handler)
+    def wrapper(event, context):
+        params: dict[str, type] = get_type_hints(handler)
+        # remove event, context, and return type if they were annotated.
+        params.pop("event", None)
+        params.pop("context", None)
+        params.pop("return", None)
+
+        repos = dict()
+        for param, class_obj in params.items():
+            if class_obj in S3Repository._repository_types:
+                repos[param] = class_obj()
+
+        return handler(event, context, **repos)
+
+    return wrapper
 
 
 class S3Repository:
     def __init__(self, bucket_name):
         self.bucket_name: str = bucket_name
+
+    def __init_subclass__(cls, *args, **kwargs):
+        """
+        Gets called once for each loaded class that sub-classes DatabaseRepository
+        """
+
+        cls._repository_types.add(cls)
 
     def _get_s3_file(self, key):
         load_path = f"s3://{self.bucket_name}/{key}"

--- a/src/poprox_storage/repositories/data_stores/s3.py
+++ b/src/poprox_storage/repositories/data_stores/s3.py
@@ -27,6 +27,8 @@ def inject_s3_repos(handler):
 
 
 class S3Repository:
+    _repository_types = set()
+
     def __init__(self, bucket_name):
         self.bucket_name: str = bucket_name
 

--- a/src/poprox_storage/repositories/experiments.py
+++ b/src/poprox_storage/repositories/experiments.py
@@ -67,6 +67,23 @@ class DbExperimentRepository(DatabaseRepository):
 
         return experiment_id
 
+    def fetch_experiment_by_id(self, experiment_id: str) -> Experiment | None:
+        expt_table = self.tables["experiments"]
+        expt_query = select(expt_table).where(expt_table.c.image_id == experiment_id)
+
+        result = self.conn.execute(expt_query).first()
+        if not result:
+            return None
+        else:
+            return Experiment(
+                experiment_id=result.experiment_id,
+                owner=None,
+                description=result.description,
+                start_date=result.start_date,
+                end_date=result.end_date,
+                phases=[],
+            )
+
     def fetch_active_expt_group_ids(self, date: datetime.date | None = None) -> list[UUID]:
         groups_tbl = self.tables["expt_groups"]
         phases_tbl = self.tables["expt_phases"]
@@ -86,6 +103,11 @@ class DbExperimentRepository(DatabaseRepository):
         )
 
         return self._id_query(groups_query)
+
+    def fetch_treatment_ids_by_experiment_id(self, experiment_id: UUID):
+        treatments_tbl = self.tables["expt_treatments"]
+        query = select(treatments_tbl.c.treatment_id).where(treatments_tbl.c.experiment_id == experiment_id)
+        return self._id_query(query)
 
     def fetch_active_treatments_by_group(self, date: datetime.date | None = None) -> dict[UUID, UUID]:
         phases_tbl = self.tables["expt_phases"]

--- a/src/poprox_storage/repositories/experiments.py
+++ b/src/poprox_storage/repositories/experiments.py
@@ -77,7 +77,6 @@ class DbExperimentRepository(DatabaseRepository):
         else:
             return Experiment(
                 experiment_id=result.experiment_id,
-                owner=None,
                 description=result.description,
                 start_date=result.start_date,
                 end_date=result.end_date,

--- a/src/poprox_storage/repositories/experiments.py
+++ b/src/poprox_storage/repositories/experiments.py
@@ -69,7 +69,7 @@ class DbExperimentRepository(DatabaseRepository):
 
     def fetch_experiment_by_id(self, experiment_id: str) -> Experiment | None:
         expt_table = self.tables["experiments"]
-        expt_query = select(expt_table).where(expt_table.c.image_id == experiment_id)
+        expt_query = select(expt_table).where(expt_table.c.experiment_id == experiment_id)
 
         result = self.conn.execute(expt_query).first()
         if not result:
@@ -106,7 +106,12 @@ class DbExperimentRepository(DatabaseRepository):
 
     def fetch_treatment_ids_by_experiment_id(self, experiment_id: UUID):
         treatments_tbl = self.tables["expt_treatments"]
-        query = select(treatments_tbl.c.treatment_id).where(treatments_tbl.c.experiment_id == experiment_id)
+        recommenders_tbl = self.tables["expt_recommenders"]
+        query = (
+            select(treatments_tbl.c.treatment_id)
+            .join(recommenders_tbl, treatments_tbl.c.recommender_id == recommenders_tbl.c.recommender_id)
+            .where(recommenders_tbl.c.experiment_id == experiment_id)
+        )
         return self._id_query(query)
 
     def fetch_active_treatments_by_group(self, date: datetime.date | None = None) -> dict[UUID, UUID]:

--- a/src/poprox_storage/repositories/newsletters.py
+++ b/src/poprox_storage/repositories/newsletters.py
@@ -81,6 +81,26 @@ class DbNewsletterRepository(DatabaseRepository):
             historic_newsletters[row.account_id][row.newsletter_id] = articles
         return historic_newsletters
 
+    def fetch_newsletters_by_treatment_id(self, expt_treatment_ids: list[UUID]) -> list[Newsletter]:
+        newsletter_table = self.tables["newsletters"]
+
+        query = select(newsletter_table).where(
+            newsletter_table.c.treatment_id.in_(expt_treatment_ids),
+        )
+        newsletter_result = self.conn.execute(query).fetchall()
+        return [
+            Newsletter(
+                newsletter_id=row.newsletter_id,
+                account_id=row.account_id,
+                treatment_id=row.treatment_id,
+                articles=[],
+                subject=row.subject,
+                body_html=row.body_html,
+                created_at=row.created_at,
+            )
+            for row in newsletter_result
+        ]
+
 
 class S3NewsletterRepository(S3Repository):
     def store_as_parquet(self, newsletters: list[Newsletter]) -> str:

--- a/src/poprox_storage/repositories/newsletters.py
+++ b/src/poprox_storage/repositories/newsletters.py
@@ -115,20 +115,18 @@ class S3NewsletterRepository(S3Repository):
         return self._write_dataframe_as_parquet(newsletter_df, bucket_name, file_prefix)
 
 
-def extract_and_flatten(newsletters):
-    def flatten(account_id, account_newsletters):
-        newsletter_list = []
-        for newsletter_id in account_newsletters:
-            articles = account_newsletters[newsletter_id]
-            for article in articles:
-                row = {}
-                row["account_id"] = str(account_id)
-                row["newsletter_id"] = str(newsletter_id)
-                row["article_id"] = str(article.article_id)
-                newsletter_list.append(row)
-        return newsletter_list
+def extract_and_flatten(newsletters: list[Newsletter]) -> list[dict]:
+    def flatten(newsletter):
+        rows = []
+        for article in newsletter.articles:
+            row = {}
+            row["account_id"] = str(newsletter.account_id)
+            row["newsletter_id"] = str(newsletter.newsletter_id)
+            row["article_id"] = str(article.article_id)
+            rows.append(row)
+        return rows
 
     final_list = []
-    for account_id in newsletters:
-        final_list.extend(flatten(account_id, newsletters[account_id]))
+    for newsletter in newsletters:
+        final_list.extend(flatten(newsletter))
     return final_list

--- a/src/poprox_storage/repositories/newsletters.py
+++ b/src/poprox_storage/repositories/newsletters.py
@@ -135,15 +135,12 @@ class DbNewsletterRepository(DatabaseRepository):
 
 class S3NewsletterRepository(S3Repository):
     def store_as_parquet(
-        self,
-        newsletters: list[Newsletter],
-        bucket_name: str,
-        file_prefix: str,
+        self, newsletters: list[Newsletter], bucket_name: str, file_prefix: str, start_time: datetime = None
     ) -> str:
         import pandas as pd
 
         newsletter_df = pd.DataFrame.from_records(extract_and_flatten(newsletters))
-        return self._write_dataframe_as_parquet(newsletter_df, bucket_name, file_prefix)
+        return self._write_dataframe_as_parquet(newsletter_df, bucket_name, file_prefix, start_time)
 
 
 def extract_and_flatten(newsletters: list[Newsletter]) -> list[dict]:

--- a/src/poprox_storage/repositories/newsletters.py
+++ b/src/poprox_storage/repositories/newsletters.py
@@ -103,11 +103,16 @@ class DbNewsletterRepository(DatabaseRepository):
 
 
 class S3NewsletterRepository(S3Repository):
-    def store_as_parquet(self, newsletters: list[Newsletter]) -> str:
+    def store_as_parquet(
+        self,
+        newsletters: list[Newsletter],
+        bucket_name: str,
+        file_prefix: str,
+    ) -> str:
         import pandas as pd
 
         newsletter_df = pd.DataFrame.from_records(extract_and_flatten(newsletters))
-        return self._write_dataframe_as_parquet(newsletter_df)
+        return self._write_dataframe_as_parquet(newsletter_df, bucket_name, file_prefix)
 
 
 def extract_and_flatten(newsletters):

--- a/src/poprox_storage/repositories/newsletters.py
+++ b/src/poprox_storage/repositories/newsletters.py
@@ -94,8 +94,8 @@ class DbNewsletterRepository(DatabaseRepository):
                 account_id=row.account_id,
                 treatment_id=row.treatment_id,
                 articles=[],
-                subject=row.subject,
-                body_html=row.body_html,
+                subject=row.email_subject,
+                body_html=row.html,
                 created_at=row.created_at,
             )
             for row in newsletter_result

--- a/tests/test_injection.py
+++ b/tests/test_injection.py
@@ -1,10 +1,8 @@
-from poprox_storage.repositories import DbArticleRepository
-from poprox_storage.repositories.data_stores.db import inject_repos
-from poprox_storage.repositories.newsletters import DbNewsletterRepository
+from poprox_storage.repositories import DbNewsletterRepository, S3ArticleRepository, inject_repos
 
 
 @inject_repos
-def example(event, context, article: DbArticleRepository, newsletter_repo: DbNewsletterRepository):
+def example(event, context, article: S3ArticleRepository, newsletter_repo: DbNewsletterRepository):
     return article, newsletter_repo
 
 
@@ -12,5 +10,5 @@ def test_repositories():
     retval = example({}, {})
     assert isinstance(retval, tuple)
     assert len(retval) == 2
-    assert isinstance(retval[0], DbArticleRepository)
+    assert isinstance(retval[0], S3ArticleRepository)
     assert isinstance(retval[1], DbNewsletterRepository)


### PR DESCRIPTION
This is preparation for a new Lambda that exports articles, newsletters, and clicks for a single experiment. Along the way, it does a few things that make that easier:

* Creates a combined `inject_repos` decorator that can inject either database or S3 repositories
* Moves existing code for flattening domain models and writing them to Parquet files on S3 into S3 repository classes
* Adds some database repository class methods for fetching the appropriate articles, newsletters, and clicks

TODOS:

- [x] Sort out `pandas` import issue surfaced by the tests
- [x] Update the imports in the `poprox_storage.repositories` init file