### PR TITLE
Unsubscribe: Tables altered and new functions added

### DIFF
--- a/src/poprox_storage/repositories/accounts.py
+++ b/src/poprox_storage/repositories/accounts.py
@@ -3,13 +3,7 @@ from datetime import date
 from uuid import UUID
 
 import sqlalchemy
-from sqlalchemy import (
-    Connection,
-    and_,
-    null,
-    or_,
-    select,
-)
+from sqlalchemy import Connection, and_, null, or_, select
 
 from poprox_concepts import Account
 from poprox_concepts.api.tracking import LoginLinkData
@@ -218,3 +212,38 @@ class DbAccountRepository(DatabaseRepository):
             data=link_data.data,
         )
         self.conn.execute(query)
+
+    def end_consent_for_account(self, account_id: UUID):
+        consent_tbl = self.tables["account_consent_log"]
+        update_query = (
+            consent_tbl.update()
+            .where(
+                consent_tbl.c.account_id == account_id,
+                consent_tbl.c.ended == null(),
+            )
+            .values(ended=sqlalchemy.text("NOW()"))
+        )
+        self.conn.execute(update_query)
+
+    def remove_email_for_account(self, account_id: UUID):
+        account_tbl = self.tables["accounts"]
+        update_query = (
+            account_tbl.update()
+            .where(
+                account_tbl.c.account_id == account_id,
+                account_tbl.c.email != null(),
+            )
+            .values(ended=null())
+        )
+        self.conn.execute(update_query)
+
+    def set_deletion_for_account(self, account_id: UUID):
+        account_tbl = self.tables["accounts"]
+        update_query = (
+            account_tbl.update()
+            .where(
+                account_tbl.c.account_id == account_id,
+            )
+            .values(ended=True)
+        )
+        self.conn.execute(update_query)


### PR DESCRIPTION
(Need to test after merging main)
Unsubscribe from emails
1. End consent/subscription - end date of all versions of consent to be set to NOW, remove from subscription table
2. Withdraw email from POPROX - set email field in accounts table to be NULL
3. Withdraw all data - add a column to accounts table (ifDeleted) and set it to true, UI to show "your response has been recorded", set up a weekly/monthly cleanup job to removing all behavioral data