### PR TITLE
add functions to allow getting the most recent newsletter for a given survey

### DIFF
--- a/src/poprox_storage/concepts/qualtrics_survey.py
+++ b/src/poprox_storage/concepts/qualtrics_survey.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import datetime
 from uuid import UUID
 
 from pydantic import BaseModel
@@ -17,6 +18,7 @@ class QualtricsSurveyInstance(BaseModel):
     survey_instance_id: UUID | None = None
     survey_id: UUID
     account_id: UUID
+    created_at: datetime | None = None
 
 
 class QualtricsSurveyResponse(BaseModel):

--- a/src/poprox_storage/repositories/newsletters.py
+++ b/src/poprox_storage/repositories/newsletters.py
@@ -106,6 +106,7 @@ class DbNewsletterRepository(DatabaseRepository):
         ]
 
     def fetch_most_recent_newsletter(self, account_id, since: datetime) -> Newsletter | None:
+        # XXX - this does not currently fetch impressions due to this feature not being needed.
         newsletters_table = self.tables["newsletters"]
 
         query = (

--- a/src/poprox_storage/repositories/newsletters.py
+++ b/src/poprox_storage/repositories/newsletters.py
@@ -105,6 +105,30 @@ class DbNewsletterRepository(DatabaseRepository):
             for row in rows
         ]
 
+    def fetch_most_recent_newsletter(self, account_id, since: datetime) -> Newsletter | None:
+        newsletters_table = self.tables["newsletters"]
+
+        query = (
+            select(newsletters_table)
+            .where(newsletters_table.c.account_id == account_id and newsletters_table.c.created_at < since)
+            .order_by(newsletters_table.c.created_at.desc())
+            .limit(1)
+        )
+
+        row = self.conn.execute(query).fetchone()
+
+        if row is None:
+            return None
+        return Newsletter(
+            newsletter_id=row.newsletter_id,
+            account_id=row.account_id,
+            treatment_id=row.treatment_id,
+            impressions=[],
+            subject=row.email_subject,
+            body_html=row.html,
+            created_at=row.created_at,
+        )
+
     def _fetch_newsletters(self, newsletters_table, impressions_table, articles_table, where_clause=None):
         newsletter_query = select(newsletters_table)
 

--- a/src/poprox_storage/repositories/qualtrics_survey.py
+++ b/src/poprox_storage/repositories/qualtrics_survey.py
@@ -88,6 +88,21 @@ class DbQualtricsSurveyRepository(DatabaseRepository):
             {"survey_id": survey.survey_id, "account_id": account_id},
         )
 
+    def fetch_survey_instance(self, survey_instance_id: UUID) -> QualtricsSurveyInstance | None:
+        survey_instance_table = self.tables["qualtrics_survey_instances"]
+
+        query = select(survey_instance_table).where(survey_instance_table.c.survey_instance_id == survey_instance_id)
+        row = self.conn.execute(query).fetchone()
+
+        if row is None:
+            return None
+        return QualtricsSurveyInstance(
+            survey_instance_id=row.survey_instance_id,
+            survey_id=row.survey_id,
+            account_id=row.account_id,
+            created_at=row.created_at,
+        )
+
     def store_survey_response(self, response: QualtricsSurveyResponse) -> UUID | None:
         survey_responses_table = self.tables["qualtrics_survey_responses"]
         return self._upsert_and_return_id(


### PR DESCRIPTION
- Added timestamp to the model object for a survey
- made a method to get survey instance given survey instance id
- made a method to fetch the most recent survey for a given user from a given timestamp.
  - Concern here -- I didn't bother fetching the impressions since we don't really need them for the current version of this task. By not fetching them this function stands our since every other function does fetch them. I'm curious what other people think about this.