### PR TITLE
Match only the latest version of articles by source and external id

### DIFF
--- a/src/poprox_storage/repositories/articles.py
+++ b/src/poprox_storage/repositories/articles.py
@@ -246,6 +246,7 @@ class DbArticleRepository(DatabaseRepository):
             and_(
                 inner_query.c.source == article_table.c.source,
                 inner_query.c.external_id == article_table.c.external_id,
+                inner_query.c.updated_at == article_table.c.created_at,
             ),
         )
         query = select(article_table).select_from(join_query)


### PR DESCRIPTION
It seems like this join is pulling back too many articles with the same source (`AP`) and external id, which appears to be causing some of our issues with duplicate articles ending up in people's recommendations. 