### PR TITLE
Extract dataset and team repository classes from `DbExperimentRepository`

### DIFF
--- a/src/poprox_storage/repositories/__init__.py
+++ b/src/poprox_storage/repositories/__init__.py
@@ -5,6 +5,7 @@ from poprox_storage.repositories.articles import (
     S3ArticleRepository,
 )
 from poprox_storage.repositories.clicks import DbClicksRepository, S3ClicksRepository
+from poprox_storage.repositories.datasets import DbDatasetRepository
 from poprox_storage.repositories.demographics import DbDemographicsRepository, S3DemographicsRepository
 from poprox_storage.repositories.experiments import (
     DbExperimentRepository,
@@ -50,6 +51,7 @@ __all__ = [
     "DbAccountRepository",
     "DbArticleRepository",
     "DbClicksRepository",
+    "DbDatasetRepository",
     "DbDemographicsRepository",
     "DbExperimentRepository",
     "DbImageRepository",

--- a/src/poprox_storage/repositories/__init__.py
+++ b/src/poprox_storage/repositories/__init__.py
@@ -15,6 +15,7 @@ from poprox_storage.repositories.images import DbImageRepository, S3ImageReposit
 from poprox_storage.repositories.newsletters import DbNewsletterRepository, S3NewsletterRepository
 from poprox_storage.repositories.placements import DbPlacementRepository
 from poprox_storage.repositories.qualtrics_survey import DbQualtricsSurveyRepository
+from poprox_storage.repositories.teams import DbTeamRepository
 
 
 def inject_repos(handler):
@@ -58,6 +59,7 @@ __all__ = [
     "DbNewsletterRepository",
     "DbPlacementRepository",
     "DbQualtricsSurveyRepository",
+    "DbTeamRepository",
     "S3AccountInterestRepository",
     "S3ArticleRepository",
     "S3ClicksRepository",

--- a/src/poprox_storage/repositories/dataset.py
+++ b/src/poprox_storage/repositories/dataset.py
@@ -1,0 +1,84 @@
+from uuid import UUID
+
+from sqlalchemy import Connection, Table, and_, select
+
+from poprox_concepts import Account
+from poprox_storage.repositories.data_stores.db import DatabaseRepository
+
+
+class DbDatasetRepository(DatabaseRepository):
+    def __init__(self, connection: Connection):
+        super().__init__(connection)
+        self.tables: dict[str, Table] = self._load_tables(
+            "account_aliases",
+            "datasets",
+            "experiments",
+            "expt_assignments",
+            "expt_groups",
+        )
+
+    def store_new_dataset(self, accounts: list[Account]) -> UUID:
+        self.conn.commit()
+        with self.conn.begin():
+            dataset_id = self._insert_dataset()
+
+            for account in accounts:
+                self._insert_account_alias(dataset_id, account)
+
+        return dataset_id
+
+    def fetch_dataset_id_by_assignment(self, assignment_id: UUID) -> UUID:
+        dataset_table = self.tables["datasets"]
+        experiment_table = self.tables["experiments"]
+        group_table = self.tables["expt_groups"]
+        assignment_table = self.tables["expt_assignments"]
+        query = (
+            select(dataset_table.c.dataset_id)
+            .join(
+                experiment_table,
+                dataset_table.c.dataset_id == experiment_table.c.dataset_id,
+            )
+            .join(
+                group_table,
+                group_table.c.experiment_id == experiment_table.c.experiment_id,
+            )
+            .join(assignment_table, assignment_table.c.group_id == group_table.c.group_id)
+            .where(assignment_table.c.assignment_id == assignment_id)
+        )
+
+        return self._id_query(query)[0]
+
+    def fetch_account_alias(self, dataset_id, account_id) -> UUID:
+        alias_table = self.tables["account_aliases"]
+        query = select(alias_table.c.alias_id).where(
+            and_(
+                alias_table.c.account_id == account_id,
+                alias_table.c.dataset_id == dataset_id,
+            )
+        )
+        return self._id_query(query)[0]
+
+    def fetch_account_aliases(self, dataset_id: UUID) -> dict[UUID, UUID]:
+        alias_table = self.tables["account_aliases"]
+        query = select(alias_table.c.account_id, alias_table.c.alias_id).where(alias_table.c.dataset_id == dataset_id)
+        rows = self.conn.execute(query).fetchall()
+        return {row.account_id: row.alias_id for row in rows}
+
+    def _insert_dataset(self) -> UUID | None:
+        return self._upsert_and_return_id(
+            self.conn,
+            self.tables["datasets"],
+            {},
+            commit=False,
+        )
+
+    def _insert_account_alias(self, dataset_id: UUID, account: Account) -> UUID | None:
+        return self._upsert_and_return_id(
+            self.conn,
+            self.tables["account_aliases"],
+            values={
+                "dataset_id": dataset_id,
+                "account_id": account.account_id,
+            },
+            commit=False,
+        )

--- a/src/poprox_storage/repositories/experiments.py
+++ b/src/poprox_storage/repositories/experiments.py
@@ -253,22 +253,6 @@ class DbExperimentRepository(DatabaseRepository):
 
         return self._id_query(query)[0]
 
-    def fetch_account_alias(self, dataset_id, account_id):
-        alias_table = self.tables["account_aliases"]
-        query = select(alias_table.c.alias_id).where(
-            and_(
-                alias_table.c.account_id == account_id,
-                alias_table.c.dataset_id == dataset_id,
-            )
-        )
-        return self._id_query(query)[0]
-
-    def fetch_account_aliases(self, dataset_id: UUID) -> dict[UUID, UUID]:
-        alias_table = self.tables["account_aliases"]
-        query = select(alias_table.c.account_id, alias_table.c.alias_id).where(alias_table.c.dataset_id == dataset_id)
-        rows = self.conn.execute(query).fetchall()
-        return {row.account_id: row.alias_id for row in rows}
-
     def _insert_experiment(self, dataset_id: UUID, experiment: Experiment) -> UUID | None:
         return self._insert_model(
             "experiments",

--- a/src/poprox_storage/repositories/teams.py
+++ b/src/poprox_storage/repositories/teams.py
@@ -1,0 +1,32 @@
+from uuid import UUID
+
+from sqlalchemy import Connection, Table
+
+from poprox_storage.concepts.experiment import Team
+from poprox_storage.repositories.data_stores.db import DatabaseRepository
+
+
+class DbTeamRepository(DatabaseRepository):
+    def __init__(self, connection: Connection):
+        super().__init__(connection)
+        self.tables: dict[str, Table] = self._load_tables(
+            "teams",
+            "team_memberships",
+        )
+
+    def store_team(
+        self,
+        team: Team,
+    ):
+        team_id = self._insert_model("teams", team, exclude={"members"}, commit=False)
+        for account_id in team.members:
+            self._insert_team_membership(team_id, account_id)
+        return team_id
+
+    def _insert_team_membership(self, team_id: UUID, account_id: UUID) -> UUID | None:
+        return self._upsert_and_return_id(
+            self.conn,
+            self.tables["team_memberships"],
+            {"team_id": team_id, "account_id": account_id},
+            commit=False,
+        )


### PR DESCRIPTION
It was okay for `DbExperimentRepository` to be a bit monolithic when it was the only thing that had to worry about teams, datasets, and account id aliases, but now that we want to apply those same aliases to datasets exported pre-study it makes sense to break it down into smaller pieces that can be used in more places.

This extracts two new repository classes and removes the corresponding code from `DbExperimentRepository`.