### PR TITLE
fix bug in get latest newsletter function

### DIFF
--- a/poprox-db/migrations/versions/2025_01_16_0930-f6ccafdb5b24_merge_revision_heads.py
+++ b/poprox-db/migrations/versions/2025_01_16_0930-f6ccafdb5b24_merge_revision_heads.py
@@ -8,9 +8,6 @@ Create Date: 2025-01-16 09:30:17.947408
 
 from typing import Sequence, Union
 
-import sqlalchemy as sa
-from alembic import op
-
 # revision identifiers, used by Alembic.
 revision: str = "f6ccafdb5b24"
 down_revision: Union[str, None] = ("adf30c8ce87e", "58deb24f5008")

--- a/src/poprox_storage/repositories/newsletters.py
+++ b/src/poprox_storage/repositories/newsletters.py
@@ -2,12 +2,7 @@ from collections import defaultdict
 from datetime import datetime, timedelta
 from uuid import UUID
 
-from sqlalchemy import (
-    Connection,
-    Table,
-    insert,
-    select,
-)
+from sqlalchemy import Connection, Table, and_, insert, select
 
 from poprox_concepts.domain import Account, Article, Impression, Newsletter
 from poprox_storage.repositories.data_stores.db import DatabaseRepository
@@ -111,7 +106,7 @@ class DbNewsletterRepository(DatabaseRepository):
 
         query = (
             select(newsletters_table)
-            .where(newsletters_table.c.account_id == account_id and newsletters_table.c.created_at < since)
+            .where(and_(newsletters_table.c.account_id == account_id, newsletters_table.c.created_at < since))
             .order_by(newsletters_table.c.created_at.desc())
             .limit(1)
         )


### PR DESCRIPTION
This was returning latest survey overall, not latest specific to this I think it was a typo using python `and` instead of sqlalchemy `and_`

