### PR TITLE
Various fixes to the `QualtricsSurveyRepository` survey data export methods

### DIFF
--- a/poprox-db/migrations/versions/2025_01_23_0938-316ffc744a8b_add_columns_to_clean_survey_responses_.py
+++ b/poprox-db/migrations/versions/2025_01_23_0938-316ffc744a8b_add_columns_to_clean_survey_responses_.py
@@ -1,0 +1,49 @@
+"""Add columns to clean survey responses table
+
+Revision ID: 316ffc744a8b
+Revises: f6ccafdb5b24
+Create Date: 2025-01-23 09:38:51.366350
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = '316ffc744a8b'
+down_revision: Union[str, None] = 'f6ccafdb5b24'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("qualtrics_clean_responses", sa.Column("account_id", sa.UUID, nullable=False))
+    op.add_column("qualtrics_clean_responses", sa.Column("survey_id", sa.UUID, nullable=False))
+    op.add_column("qualtrics_clean_responses", sa.Column("qualtrics_id", sa.UUID, nullable=False))
+    op.add_column("qualtrics_clean_responses", sa.Column("survey_code", sa.UUID, nullable=True))
+
+    op.create_foreign_key(
+        "fk_qualtrics_clean_responses_account_id",
+        "qualtrics_clean_responses",
+        "accounts",
+        ["account_id"],
+        ["account_id"],
+    )
+
+    op.create_foreign_key(
+        "fk_qualtrics_clean_responses_survey_id",
+        "qualtrics_clean_responses",
+        "qualtrics_surveys",
+        ["survey_id"],
+        ["survey_id"],
+    )
+
+def downgrade() -> None:
+    op.drop_constraint("fk_survey_calendar_survey_id", "qualtrics_survey_calendar", type_="foreignkey")
+    op.drop_constraint("fk_qualtrics_clean_responses_account_id", "qualtrics_clean_responses", type_="foreignkey")
+
+    op.drop_column("qualtrics_clean_responses", "survey_code")
+    op.drop_column("qualtrics_clean_responses", "qualtrics_id")
+    op.drop_column("qualtrics_clean_responses", "survey_id")
+    op.drop_column("qualtrics_clean_responses", "account_id")

--- a/poprox-db/migrations/versions/2025_01_23_0938-316ffc744a8b_add_columns_to_clean_survey_responses_.py
+++ b/poprox-db/migrations/versions/2025_01_23_0938-316ffc744a8b_add_columns_to_clean_survey_responses_.py
@@ -20,8 +20,8 @@ depends_on: Union[str, Sequence[str], None] = None
 def upgrade() -> None:
     op.add_column("qualtrics_clean_responses", sa.Column("account_id", sa.UUID, nullable=False))
     op.add_column("qualtrics_clean_responses", sa.Column("survey_id", sa.UUID, nullable=False))
-    op.add_column("qualtrics_clean_responses", sa.Column("qualtrics_id", sa.UUID, nullable=False))
-    op.add_column("qualtrics_clean_responses", sa.Column("survey_code", sa.UUID, nullable=True))
+    op.add_column("qualtrics_clean_responses", sa.Column("qualtrics_id", sa.String, nullable=False))
+    op.add_column("qualtrics_clean_responses", sa.Column("survey_code", sa.String, nullable=True))
 
     op.create_foreign_key(
         "fk_qualtrics_clean_responses_account_id",

--- a/src/poprox_storage/repositories/datasets.py
+++ b/src/poprox_storage/repositories/datasets.py
@@ -10,12 +10,7 @@ class DbDatasetRepository(DatabaseRepository):
     def __init__(self, connection: Connection):
         super().__init__(connection)
         self.tables: dict[str, Table] = self._load_tables(
-            "account_aliases",
-            "datasets",
-            "experiments",
-            "expt_assignments",
-            "expt_groups",
-            "teams"
+            "account_aliases", "datasets", "experiments", "expt_assignments", "expt_groups", "teams"
         )
 
     def store_new_dataset(self, accounts: list[Account], team_id: UUID) -> UUID:

--- a/src/poprox_storage/repositories/datasets.py
+++ b/src/poprox_storage/repositories/datasets.py
@@ -16,6 +16,7 @@ class DbDatasetRepository(DatabaseRepository):
             "experiments",
             "expt_assignments",
             "expt_groups",
+            "teams"
         )
 
     def store_new_dataset(self, accounts: list[Account], owner: Team | None = None) -> UUID:
@@ -66,10 +67,21 @@ class DbDatasetRepository(DatabaseRepository):
         return {row.account_id: row.alias_id for row in rows}
 
     def _insert_dataset(self, team: Team | None) -> UUID | None:
+        team_id = self._upsert_and_return_id(
+            self.conn,
+            self.tables["teams"],
+            {
+                "team_id": team.team_id if team else None,
+                "team_name": team.team_name if team else None
+            },
+            constraint="teams_pkey",
+            commit=False
+        )
+
         return self._upsert_and_return_id(
             self.conn,
             self.tables["datasets"],
-            {"team_id": team.team_id if team else None},
+            {"team_id": team_id if team_id else None},
             commit=False,
         )
 

--- a/src/poprox_storage/repositories/newsletters.py
+++ b/src/poprox_storage/repositories/newsletters.py
@@ -71,8 +71,7 @@ class DbNewsletterRepository(DatabaseRepository):
 
         if accounts:
             where_clause = and_(
-                where_clause,
-                newsletters_table.c.account_id.in_([acct.account_id for acct in accounts])
+                where_clause, newsletters_table.c.account_id.in_([acct.account_id for acct in accounts])
             )
 
         return self._fetch_newsletters(

--- a/src/poprox_storage/repositories/newsletters.py
+++ b/src/poprox_storage/repositories/newsletters.py
@@ -2,7 +2,13 @@ from collections import defaultdict
 from datetime import datetime, timedelta
 from uuid import UUID
 
-from sqlalchemy import Connection, Table, and_, insert, select
+from sqlalchemy import (
+    Connection,
+    Table,
+    and_,
+    insert,
+    select,
+)
 
 from poprox_concepts.domain import Account, Article, Impression, Newsletter
 from poprox_storage.repositories.data_stores.db import DatabaseRepository
@@ -54,18 +60,26 @@ class DbNewsletterRepository(DatabaseRepository):
             newsletters_table.c.account_id.in_([acct.account_id for acct in accounts]),
         )
 
-    def fetch_newsletters_since(self, days_ago=90) -> list[Newsletter]:
+    def fetch_newsletters_since(self, days_ago=90, accounts: list[Account] | None = None) -> list[Newsletter]:
         newsletters_table = self.tables["newsletters"]
         impressions_table = self.tables["impressions"]
         articles_table = self.tables["articles"]
 
         cutoff = datetime.now() - timedelta(days=days_ago)
 
+        where_clause = newsletters_table.c.created_at >= cutoff
+
+        if accounts:
+            where_clause = and_(
+                where_clause,
+                newsletters_table.c.account_id.in_([acct.account_id for acct in accounts])
+            )
+
         return self._fetch_newsletters(
             newsletters_table,
             impressions_table,
             articles_table,
-            newsletters_table.c.created_at >= cutoff,
+            where_clause,
         )
 
     def fetch_newsletters_by_treatment_id(self, expt_treatment_ids: list[UUID]) -> list[Newsletter]:

--- a/src/poprox_storage/repositories/qualtrics_survey.py
+++ b/src/poprox_storage/repositories/qualtrics_survey.py
@@ -132,9 +132,11 @@ class DbQualtricsSurveyRepository(DatabaseRepository):
             where_clause = and_(where_clause, survey_instance_table.c.survey_id.in_(survey_ids))
 
         return self._fetch_survey_responses(where_clause)
-    
+
     def fetch_survey_responses_since(
-        self, days_ago: int, accounts: list[Account] | None = None, 
+        self,
+        days_ago: int,
+        accounts: list[Account] | None = None,
     ) -> list[tuple[QualtricsSurveyInstance, QualtricsSurveyResponse]]:
         instances_table = self.tables["qualtrics_survey_instances"]
 
@@ -148,7 +150,7 @@ class DbQualtricsSurveyRepository(DatabaseRepository):
         return self._fetch_survey_responses(where_clause)
 
     def _fetch_survey_responses(
-        self, where_clause = None
+        self, where_clause=None
     ) -> list[tuple[QualtricsSurveyInstance, QualtricsSurveyResponse]]:
         survey_instance_table = self.tables["qualtrics_survey_instances"]
         survey_responses_table = self.tables["qualtrics_survey_responses"]
@@ -162,7 +164,7 @@ class DbQualtricsSurveyRepository(DatabaseRepository):
 
         if where_clause is not None:
             response_query = response_query.where(where_clause)
-        
+
         response_query = response_query.order_by(survey_responses_table.c.created_at.desc())
         results = self.conn.execute(response_query).fetchall()
 
@@ -186,7 +188,9 @@ class DbQualtricsSurveyRepository(DatabaseRepository):
 
         return self._upsert_and_return_id(self.conn, clean_table, response.model_dump())
 
-    def fetch_clean_responses_since(self, days_ago=1, accounts: list[Account] | None = None) -> list[QualtricsCleanResponse]:
+    def fetch_clean_responses_since(
+        self, days_ago=1, accounts: list[Account] | None = None
+    ) -> list[QualtricsCleanResponse]:
         surveys_table = self.tables["qualtrics_surveys"]
         instances_table = self.tables["qualtrics_survey_instances"]
         responses_table = self.tables["qualtrics_clean_responses"]
@@ -206,7 +210,7 @@ class DbQualtricsSurveyRepository(DatabaseRepository):
         if accounts:
             account_ids = [acct.account_id for acct in accounts]
             response_query = response_query.where(instances_table.c.account_id.in_(account_ids))
-        
+
         results = self.conn.execute(response_query).fetchall()
 
         return [

--- a/src/poprox_storage/repositories/teams.py
+++ b/src/poprox_storage/repositories/teams.py
@@ -18,7 +18,7 @@ class DbTeamRepository(DatabaseRepository):
         self,
         team: Team,
     ):
-        team_id = self._insert_model("teams", team, exclude={"members"}, commit=False)
+        team_id = self._insert_model("teams", team, exclude={"members"}, constraint="teams_pkey", commit=False)
         for account_id in team.members:
             self._insert_team_membership(team_id, account_id)
         return team_id

--- a/tests/repositories/test_experiments.py
+++ b/tests/repositories/test_experiments.py
@@ -59,7 +59,7 @@ def test_store_experiment():
             ...
 
         experiment.owner.team_id = team_repo.store_team(experiment.owner)
-        dataset_id = dataset_repo.store_new_dataset([account], experiment.owner)
+        dataset_id = dataset_repo.store_new_dataset([account], experiment.owner.team_id)
         experiment_id = experiment_repo.store_experiment(experiment, [], dataset_id)
 
         assert isinstance(experiment_id, UUID)


### PR DESCRIPTION
This makes a few tweaks to the QualtricsSurveyRepository methods to allow fetching raw/clean survey responses for specific accounts, which is useful for data exports. It also expands the set of columns in the clean responses database table, and adjusts the way dataset storage works in combination with creating new teams (as dataset owners.)