### PR TITLE
Add experiment extra column to impressions table and update fetch

### DIFF
--- a/poprox-db/migrations/versions/2024_08_21_1639-4fc4a6030444_create_article_placements_table.py
+++ b/poprox-db/migrations/versions/2024_08_21_1639-4fc4a6030444_create_article_placements_table.py
@@ -56,7 +56,7 @@ def upgrade() -> None:
 def downgrade() -> None:
     # Drop the FK constraint before dropping the table
     op.drop_constraint(
-        "fk_article_placements_articles",
+        "fk_articles_placements_articles",
         "article_placements",
         type_="foreignkey",
     )

--- a/poprox-db/migrations/versions/2025_01_31_1607-b02a1eb29fee_add_experiment_extra_for_locality_.py
+++ b/poprox-db/migrations/versions/2025_01_31_1607-b02a1eb29fee_add_experiment_extra_for_locality_.py
@@ -1,0 +1,35 @@
+"""add experiment_extra for locality experiment logging
+
+Revision ID: b02a1eb29fee
+Revises: f6ccafdb5b24
+Create Date: 2025-01-31 16:07:04.005073
+
+"""
+from typing import Sequence, Union
+from sqlalchemy.dialects.postgresql import JSONB
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'b02a1eb29fee'
+down_revision: Union[str, None] = 'f6ccafdb5b24'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Add a single column of json type corresponding to the experiment_extra
+    op.add_column(
+        "impressions",
+        sa.Column(
+            "experiment_extra",
+            JSONB
+        ),
+    )
+
+
+def downgrade() -> None:
+    # Drop the new primary key column
+    op.drop_column("impressions", "experiment_extra")

--- a/poprox-db/migrations/versions/2025_01_31_1607-b02a1eb29fee_add_experiment_extra_for_locality_.py
+++ b/poprox-db/migrations/versions/2025_01_31_1607-b02a1eb29fee_add_experiment_extra_for_locality_.py
@@ -6,11 +6,10 @@ Create Date: 2025-01-31 16:07:04.005073
 
 """
 from typing import Sequence, Union
-from sqlalchemy.dialects.postgresql import JSONB
 
-from alembic import op
 import sqlalchemy as sa
-
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB
 
 # revision identifiers, used by Alembic.
 revision: str = 'b02a1eb29fee'
@@ -25,7 +24,7 @@ def upgrade() -> None:
         "impressions",
         sa.Column(
             "experiment_extra",
-            JSONB
+            JSONB,
         ),
     )
 

--- a/poprox-db/migrations/versions/2025_01_31_1607-b02a1eb29fee_add_extra_column_for_logging_.py
+++ b/poprox-db/migrations/versions/2025_01_31_1607-b02a1eb29fee_add_extra_column_for_logging_.py
@@ -1,4 +1,4 @@
-"""add experiment_extra for locality experiment logging
+"""add extra column for recommender logging
 
 Revision ID: b02a1eb29fee
 Revises: f6ccafdb5b24
@@ -23,7 +23,7 @@ def upgrade() -> None:
     op.add_column(
         "impressions",
         sa.Column(
-            "experiment_extra",
+            "extra",
             JSONB,
         ),
     )
@@ -31,4 +31,4 @@ def upgrade() -> None:
 
 def downgrade() -> None:
     # Drop the new primary key column
-    op.drop_column("impressions", "experiment_extra")
+    op.drop_column("impressions", "extra")

--- a/src/poprox_storage/repositories/newsletters.py
+++ b/src/poprox_storage/repositories/newsletters.py
@@ -39,7 +39,7 @@ class DbNewsletterRepository(DatabaseRepository):
                     newsletter_id=str(newsletter.newsletter_id),
                     article_id=str(impression.article.article_id),
                     position=impression.position,
-                    experiment_extra=impression.experiment_extra,
+                    extra=impression.extra,
                 )
                 self.conn.execute(stmt)
 
@@ -88,7 +88,7 @@ class DbNewsletterRepository(DatabaseRepository):
             impressions_table.c.newsletter_id,
             impressions_table.c.article_id,
             impressions_table.c.position,
-            impressions_table.c.experiment_extra,
+            impressions_table.c.extra,
         ).where(
             impressions_table.c.newsletter_id.in_(newsletter_ids),
         )
@@ -98,7 +98,7 @@ class DbNewsletterRepository(DatabaseRepository):
                 newsletter_id=row.newsletter_id,
                 article_id=row.article_id,
                 position=row.position,
-                experiment_extra=row.experiment_extra,
+                extra=row.extra,
             )
             for row in rows
         ]
@@ -206,7 +206,7 @@ def extract_and_flatten(newsletters: list[Newsletter]) -> list[dict]:
             record["article_id"] = str(impression.article.article_id)
             record["position"] = impression.position
             record["created_at"] = newsletter.created_at
-            record["experiment_extra"] = impression.experiment_extra
+            record["extra"] = impression.extra
             records.append(record)
         impression_records.extend(records)
     return impression_records

--- a/src/poprox_storage/repositories/newsletters.py
+++ b/src/poprox_storage/repositories/newsletters.py
@@ -39,7 +39,7 @@ class DbNewsletterRepository(DatabaseRepository):
                     newsletter_id=str(newsletter.newsletter_id),
                     article_id=str(impression.article.article_id),
                     position=impression.position,
-                    experiment_extra=impression.experiment_extra
+                    experiment_extra=impression.experiment_extra,
                 )
                 self.conn.execute(stmt)
 
@@ -88,7 +88,7 @@ class DbNewsletterRepository(DatabaseRepository):
             impressions_table.c.newsletter_id,
             impressions_table.c.article_id,
             impressions_table.c.position,
-            impressions_table.c.experiment_extra
+            impressions_table.c.experiment_extra,
         ).where(
             impressions_table.c.newsletter_id.in_(newsletter_ids),
         )
@@ -98,7 +98,7 @@ class DbNewsletterRepository(DatabaseRepository):
                 newsletter_id=row.newsletter_id,
                 article_id=row.article_id,
                 position=row.position,
-                experiment_extra=row.experiment_extra
+                experiment_extra=row.experiment_extra,
             )
             for row in rows
         ]

--- a/src/poprox_storage/repositories/newsletters.py
+++ b/src/poprox_storage/repositories/newsletters.py
@@ -39,6 +39,7 @@ class DbNewsletterRepository(DatabaseRepository):
                     newsletter_id=str(newsletter.newsletter_id),
                     article_id=str(impression.article.article_id),
                     position=impression.position,
+                    experiment_extra=impression.experiment_extra
                 )
                 self.conn.execute(stmt)
 
@@ -87,6 +88,7 @@ class DbNewsletterRepository(DatabaseRepository):
             impressions_table.c.newsletter_id,
             impressions_table.c.article_id,
             impressions_table.c.position,
+            impressions_table.c.experiment_extra
         ).where(
             impressions_table.c.newsletter_id.in_(newsletter_ids),
         )
@@ -96,6 +98,7 @@ class DbNewsletterRepository(DatabaseRepository):
                 newsletter_id=row.newsletter_id,
                 article_id=row.article_id,
                 position=row.position,
+                experiment_extra=row.experiment_extra
             )
             for row in rows
         ]
@@ -203,6 +206,7 @@ def extract_and_flatten(newsletters: list[Newsletter]) -> list[dict]:
             record["article_id"] = str(impression.article.article_id)
             record["position"] = impression.position
             record["created_at"] = newsletter.created_at
+            record["experiment_extra"] = impression.experiment_extra
             records.append(record)
         impression_records.extend(records)
     return impression_records


### PR DESCRIPTION
For the new column adding, it passed local db test.
This is associated with the data model change in https://github.com/CCRI-POPROX/poprox-concepts/pull/37 (I think it's also why the first PyTest test failed since that PR is not merged yet).