### PR TITLE
Remove database commit management and account alias creation from experiment/dataset repos

### DIFF
--- a/src/poprox_storage/repositories/datasets.py
+++ b/src/poprox_storage/repositories/datasets.py
@@ -14,12 +14,10 @@ class DbDatasetRepository(DatabaseRepository):
         )
 
     def store_new_dataset(self, accounts: list[Account], team_id: UUID) -> UUID:
-        self.conn.commit()
-        with self.conn.begin():
-            dataset_id = self._insert_dataset(team_id)
+        dataset_id = self._insert_dataset(team_id)
 
-            for account in accounts:
-                self._insert_account_alias(dataset_id, account)
+        for account in accounts:
+            self._insert_account_alias(dataset_id, account)
 
         return dataset_id
 

--- a/src/poprox_storage/repositories/experiments.py
+++ b/src/poprox_storage/repositories/experiments.py
@@ -45,8 +45,6 @@ class DbExperimentRepository(DatabaseRepository):
         for group in experiment.groups:
             group.group_id = self._insert_expt_group(experiment_id, group)
             for account in assignments.get(group.name, []):
-                self._insert_account_alias(dataset_id, account)
-
                 assignment = Assignment(account_id=account.account_id, group_id=group.group_id)
                 self._insert_expt_assignment(assignment)
 

--- a/src/poprox_storage/repositories/experiments.py
+++ b/src/poprox_storage/repositories/experiments.py
@@ -40,28 +40,26 @@ class DbExperimentRepository(DatabaseRepository):
         dataset_id: UUID,
     ):
         assignments = assignments or {}
-        self.conn.commit()
-        with self.conn.begin():
-            experiment_id = self._insert_experiment(dataset_id, experiment)
+        experiment_id = self._insert_experiment(dataset_id, experiment)
 
-            for group in experiment.groups:
-                group.group_id = self._insert_expt_group(experiment_id, group)
-                for account in assignments.get(group.name, []):
-                    self._insert_account_alias(dataset_id, account)
+        for group in experiment.groups:
+            group.group_id = self._insert_expt_group(experiment_id, group)
+            for account in assignments.get(group.name, []):
+                self._insert_account_alias(dataset_id, account)
 
-                    assignment = Assignment(account_id=account.account_id, group_id=group.group_id)
-                    self._insert_expt_assignment(assignment)
+                assignment = Assignment(account_id=account.account_id, group_id=group.group_id)
+                self._insert_expt_assignment(assignment)
 
-            for recommender in experiment.recommenders:
-                recommender.recommender_id = self._insert_expt_recommender(
-                    experiment_id,
-                    recommender,
-                )
+        for recommender in experiment.recommenders:
+            recommender.recommender_id = self._insert_expt_recommender(
+                experiment_id,
+                recommender,
+            )
 
-            for phase in experiment.phases:
-                phase.phase_id = self._insert_expt_phase(experiment_id, phase)
-                for treatment in phase.treatments:
-                    self._insert_expt_treatment(phase.phase_id, treatment)
+        for phase in experiment.phases:
+            phase.phase_id = self._insert_expt_phase(experiment_id, phase)
+            for treatment in phase.treatments:
+                self._insert_expt_treatment(phase.phase_id, treatment)
 
         return experiment_id
 


### PR DESCRIPTION
The experiment side of this used to be a stand-alone "one stop shop" for creating an experiment and everything involved in that, but we've since split out team/dataset/alias creation into separate repos. In order to avoid partially creating the relevant database records when loading an experiment manifest, the database commit management needs to happen at the Lambda level.