### PR TITLE
Add a function `fetch_survey_metadata` in `DbQualtricsSurveyRepository`.

### DIFF
--- a/src/poprox_storage/repositories/qualtrics_survey.py
+++ b/src/poprox_storage/repositories/qualtrics_survey.py
@@ -286,6 +286,31 @@ class DbQualtricsSurveyRepository(DatabaseRepository):
             question_metadata_raw=row.question_metadata_raw,
         )
 
+    def fetch_survey_metadata(self, survey_ids: list[UUID]) -> list[QualtricsSurvey]:
+        survey_table = self.tables["qualtrics_surveys"]
+
+        query = select(
+            survey_table.c.survey_id,
+            survey_table.c.qualtrics_id,
+            survey_table.c.base_url,
+            survey_table.c.continuation_token,
+            survey_table.c.active,
+            survey_table.c.question_metadata_raw,
+        ).where(survey_table.c.survey_id.in_(survey_ids))
+
+        results = self.conn.execute(query).fetchall()
+        return [
+            QualtricsSurvey(
+                survey_id=row.survey_id,
+                qualtrics_id=row.qualtrics_id,
+                base_url=row.base_url,
+                continuation_token=row.continuation_token,
+                active=row.active,
+                question_metadata_raw=row.question_metadata_raw,
+            )
+            for row in results
+        ]
+
 
 class S3QualtricsSurveyRepository(S3Repository):
     def __init__(self, bucket_name):


### PR DESCRIPTION
This function fetches survey metadata for  the given list of `survey_ids` from the `qualtrics_surveys` table and returns a list of `QualtricsSurvey` objects.