### PR TITLE
Adjust subscriber query and rename some columns in data exports

### DIFF
--- a/src/poprox_storage/repositories/accounts.py
+++ b/src/poprox_storage/repositories/accounts.py
@@ -1,5 +1,5 @@
 import logging
-from datetime import date
+from datetime import date, datetime, timedelta
 from uuid import UUID, uuid4
 
 import sqlalchemy
@@ -194,6 +194,17 @@ class DbAccountRepository(DatabaseRepository):
         subscription_tbl = self.tables["subscriptions"]
 
         account_query = select(subscription_tbl.c.account_id).where(subscription_tbl.c.ended == null())
+        account_ids = self._id_query(account_query)
+        return self.fetch_accounts(account_ids)
+
+    def fetch_subscribed_accounts_since(self, days_ago=1) -> list[Account]:
+        subscription_tbl = self.tables["subscriptions"]
+
+        cutoff = datetime.now() - timedelta(days=days_ago)
+
+        account_query = select(subscription_tbl.c.account_id).where(
+            or_(subscription_tbl.c.ended == null(), subscription_tbl.c.ended >= cutoff)
+        )
         account_ids = self._id_query(account_query)
         return self.fetch_accounts(account_ids)
 

--- a/src/poprox_storage/repositories/clicks.py
+++ b/src/poprox_storage/repositories/clicks.py
@@ -142,7 +142,7 @@ def extract_and_flatten(clicks_by_user: dict[UUID, list[Click]]) -> list[dict]:
         row["profile_id"] = str(profile_id)
         row["newsletter_id"] = str(click.newsletter_id)
         row["article_id"] = str(click.article_id)
-        row["timestamp"] = click.timestamp
+        row["clicked_at"] = click.timestamp
         return row
 
     flattened_rows = []

--- a/src/poprox_storage/repositories/newsletters.py
+++ b/src/poprox_storage/repositories/newsletters.py
@@ -243,7 +243,7 @@ def extract_and_flatten(newsletters: list[Newsletter]) -> list[dict]:
         records = []
         for impression in newsletter.impressions:
             record = {}
-            record["account_id"] = str(newsletter.account_id)
+            record["profile_id"] = str(newsletter.account_id)
             record["newsletter_id"] = str(newsletter.newsletter_id)
             record["article_id"] = str(impression.article.article_id)
             record["position"] = impression.position

--- a/src/poprox_storage/repositories/qualtrics_survey.py
+++ b/src/poprox_storage/repositories/qualtrics_survey.py
@@ -373,7 +373,7 @@ def extract_and_flatten(responses: list[QualtricsCleanResponse]):
 
         return [
             {
-                "account_id": str(response.account_id),
+                "profile_id": str(response.account_id),
                 "survey_id": str(response.survey_id),
                 "qualtrics_id": response.qualtrics_id,
                 "survey_code": response.survey_code,


### PR DESCRIPTION
This is based on Ed's feedback on exported data, and includes a small fix to the determination of which users should be included in the export. Namely, anyone who _was_ subscribed during the last 30 days should be included (not just people with currently active subscriptions), so this adds a method to find those accounts.