### PR TITLE
Create candidate pool tables and create pool repository

### DIFF
--- a/poprox-db/migrations/versions/2025_04_28_1246-4baca0cff3b8_create_candidates_table.py
+++ b/poprox-db/migrations/versions/2025_04_28_1246-4baca0cff3b8_create_candidates_table.py
@@ -19,14 +19,22 @@ depends_on: Union[str, Sequence[str], None] = None
 
 def upgrade() -> None:
     op.create_table(
-        "candidate_articles",
-        sa.Column("article_id",sa.UUID, nullable=False),
-        sa.Column("candidate_on", sa.Date, nullable=False),
+        "candidate_pools",
+        sa.Column("candidate_pool_id", sa.UUID, primary_key=True),
+        sa.Column("pool_type", sa.String, nullable=False),
         sa.Column("created_at", sa.DateTime, nullable=False, server_default=sa.text("NOW()")),
     )
-    op.create_unique_constraint("uq_candidate_articles", "candidate_articles", ("article_id", "candidate_on"))
+
+    op.create_table(
+        "candidate_articles",
+        sa.Column("candidate_pool_id", sa.UUID, primary_key=True),
+        sa.Column("article_id",sa.UUID, nullable=False),
+        sa.Column("created_at", sa.DateTime, nullable=False, server_default=sa.text("NOW()")),
+    )
+    op.create_unique_constraint("uq_candidate_articles", "candidate_articles", ("candidate_pool_id", "article_id"))
 
 
 def downgrade() -> None:
     op.drop_constraint("uq_candidate_articles", "candidate_articles")
     op.drop_table("candidate_articles")
+    op.drop_table("candidate_pools")

--- a/poprox-db/migrations/versions/2025_04_28_1246-4baca0cff3b8_create_candidates_table.py
+++ b/poprox-db/migrations/versions/2025_04_28_1246-4baca0cff3b8_create_candidates_table.py
@@ -1,0 +1,32 @@
+"""create candidates table
+
+Revision ID: 4baca0cff3b8
+Revises: bad8a290077a
+Create Date: 2025-04-28 12:46:08.761767
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = '4baca0cff3b8'
+down_revision: Union[str, None] = 'bad8a290077a'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "candidate_articles",
+        sa.Column("article_id",sa.UUID, nullable=False),
+        sa.Column("candidate_on", sa.Date, nullable=False),
+        sa.Column("created_at", sa.DateTime, nullable=False, server_default=sa.text("NOW()")),
+    )
+    op.create_unique_constraint("uq_candidate_articles", "candidate_articles", ("article_id", "candidate_on"))
+
+
+def downgrade() -> None:
+    op.drop_constraint("uq_candidate_articles", "candidate_articles")
+    op.drop_table("candidate_articles")

--- a/src/poprox_storage/repositories/__init__.py
+++ b/src/poprox_storage/repositories/__init__.py
@@ -14,6 +14,7 @@ from poprox_storage.repositories.experiments import (
 from poprox_storage.repositories.images import DbImageRepository, S3ImageRepository
 from poprox_storage.repositories.newsletters import DbNewsletterRepository, S3NewsletterRepository
 from poprox_storage.repositories.placements import DbPlacementRepository
+from poprox_storage.repositories.pools import DbCandidatePoolRepository
 from poprox_storage.repositories.qualtrics_survey import DbQualtricsSurveyRepository, S3QualtricsSurveyRepository
 from poprox_storage.repositories.teams import DbTeamRepository
 
@@ -51,6 +52,7 @@ __all__ = [
     "DbAccountInterestRepository",
     "DbAccountRepository",
     "DbArticleRepository",
+    "DbCandidatePoolRepository",
     "DbClicksRepository",
     "DbDatasetRepository",
     "DbDemographicsRepository",

--- a/src/poprox_storage/repositories/articles.py
+++ b/src/poprox_storage/repositories/articles.py
@@ -1,7 +1,7 @@
 import json
 import logging
 from collections import defaultdict
-from datetime import date, datetime, timedelta
+from datetime import datetime, timedelta
 from uuid import UUID
 
 import boto3
@@ -285,6 +285,7 @@ class DbArticleRepository(DatabaseRepository):
             query = query.where(where_clause)
 
         return _fetch_articles(self.conn, query)
+
 
 def _fetch_articles(conn, article_query) -> list[Article]:
     result = conn.execute(article_query).fetchall()

--- a/src/poprox_storage/repositories/pools.py
+++ b/src/poprox_storage/repositories/pools.py
@@ -1,0 +1,75 @@
+import logging
+from uuid import UUID, uuid4
+
+from sqlalchemy import (
+    Connection,
+    Table,
+    desc,
+    select,
+)
+from sqlalchemy.dialects.postgresql import insert
+
+from poprox_concepts.domain import Article
+from poprox_storage.repositories.articles import _fetch_articles
+from poprox_storage.repositories.data_stores.db import DatabaseRepository
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+
+
+class DbCandidatePoolRepository(DatabaseRepository):
+    def __init__(self, connection: Connection):
+        super().__init__(connection)
+        self.tables: dict[str, Table] = self._load_tables(
+            "articles",
+            "candidate_pools",
+            "candidate_articles"
+        )
+
+    def store_candidate_pool(self, pool_type: str, articles: list[Article]):
+        candidate_pools_table = self.tables["candidate_pools"]
+        candidate_articles_table = self.tables["candidate_articles"]
+
+        candidate_pool_id: UUID = uuid4()
+
+        set_insert_stmt = (
+            insert(candidate_pools_table)
+            .values({"candidate_pool_id": candidate_pool_id, "pool_type": pool_type})
+        )
+        self.conn.execute(set_insert_stmt)
+
+        insert_stmt = (
+            insert(candidate_articles_table)
+            .values([{"candidate_pool_id": candidate_pool_id, "article_id": article.article_id} for article in articles])
+            .on_conflict_do_nothing(constraint="uq_candidate_articles")
+        )
+        self.conn.execute(insert_stmt)
+
+        return candidate_pool_id
+
+    def fetch_candidate_pool(self, candidate_pool_id: UUID) -> list[Article]:
+        candidate_articles_table = self.tables["candidate_articles"]
+        articles_table = self.tables["articles"]
+
+        query = (
+            select(candidate_articles_table)
+            .join(articles_table, candidate_articles_table.c.article_id == articles_table.c.article_id)
+            .where(candidate_articles_table.c.candidate_pool_id == candidate_pool_id)
+        )
+
+        return _fetch_articles(self.conn, query)
+
+    def fetch_latest_pool_of_type(self, candidate_pool_type: str) -> UUID:
+        candidate_pools_table = self.tables["candidate_pools"]
+
+        query = (
+            select(candidate_pools_table)
+            .where(candidate_pools_table.c.pool_type == candidate_pool_type)
+            .order_by(desc(candidate_pools_table.c.created_at))
+            .limit(1)
+        )
+
+        result = self.conn.execute(query).fetchone()
+
+        return result.candidate_pool_id
+

--- a/src/poprox_storage/repositories/pools.py
+++ b/src/poprox_storage/repositories/pools.py
@@ -20,11 +20,7 @@ logger.setLevel(logging.DEBUG)
 class DbCandidatePoolRepository(DatabaseRepository):
     def __init__(self, connection: Connection):
         super().__init__(connection)
-        self.tables: dict[str, Table] = self._load_tables(
-            "articles",
-            "candidate_pools",
-            "candidate_articles"
-        )
+        self.tables: dict[str, Table] = self._load_tables("articles", "candidate_pools", "candidate_articles")
 
     def store_candidate_pool(self, pool_type: str, articles: list[Article]):
         candidate_pools_table = self.tables["candidate_pools"]
@@ -32,15 +28,16 @@ class DbCandidatePoolRepository(DatabaseRepository):
 
         candidate_pool_id: UUID = uuid4()
 
-        set_insert_stmt = (
-            insert(candidate_pools_table)
-            .values({"candidate_pool_id": candidate_pool_id, "pool_type": pool_type})
+        set_insert_stmt = insert(candidate_pools_table).values(
+            {"candidate_pool_id": candidate_pool_id, "pool_type": pool_type}
         )
         self.conn.execute(set_insert_stmt)
 
         insert_stmt = (
             insert(candidate_articles_table)
-            .values([{"candidate_pool_id": candidate_pool_id, "article_id": article.article_id} for article in articles])
+            .values(
+                [{"candidate_pool_id": candidate_pool_id, "article_id": article.article_id} for article in articles]
+            )
             .on_conflict_do_nothing(constraint="uq_candidate_articles")
         )
         self.conn.execute(insert_stmt)
@@ -72,4 +69,3 @@ class DbCandidatePoolRepository(DatabaseRepository):
         result = self.conn.execute(query).fetchone()
 
         return result.candidate_pool_id
-


### PR DESCRIPTION
This will allow us to explicitly record what we considered to be part of the candidate pool each day rather than inferring what was part of the pool from the date. I think this will help us avoid including the same article multiple days in a row, and also make it easier to do offline evaluation down the road.