### PR TITLE
Update click and survey repositories for experiment dataset export

### DIFF
--- a/src/poprox_storage/repositories/__init__.py
+++ b/src/poprox_storage/repositories/__init__.py
@@ -9,6 +9,7 @@ from poprox_storage.repositories.datasets import DbDatasetRepository
 from poprox_storage.repositories.demographics import DbDemographicsRepository, S3DemographicsRepository
 from poprox_storage.repositories.experiments import (
     DbExperimentRepository,
+    S3AssignmentsRepository,
     S3ExperimentRepository,
 )
 from poprox_storage.repositories.images import DbImageRepository, S3ImageRepository
@@ -62,6 +63,7 @@ __all__ = [
     "DbTeamRepository",
     "S3AccountInterestRepository",
     "S3ArticleRepository",
+    "S3AssignmentsRepository",
     "S3ClicksRepository",
     "S3DemographicsRepository",
     "S3ExperimentRepository",

--- a/src/poprox_storage/repositories/experiments.py
+++ b/src/poprox_storage/repositories/experiments.py
@@ -431,6 +431,33 @@ class S3ExperimentRepository(S3Repository):
         manifest_toml = self._get_s3_file(manifest_file_key)
         return parse_manifest_toml(manifest_toml)
 
+    def store_as_parquet(
+        self,
+        experiment: Experiment,
+        bucket_name: str,
+        file_prefix: str,
+        start_time: datetime = None,
+    ) -> str:
+        records = self._extract_and_flatten(experiment)
+        return self._write_records_as_parquet(records, bucket_name, file_prefix, start_time)
+
+    def _extract_and_flatten(self, experiment: Experiment) -> list[dict]:
+        records = []
+        for phase in experiment.phases:
+            for treatment in phase.treatments:
+                record = {}
+                record["treatment_id"] = str(treatment.treatment_id)
+                record["phase_id"] = str(phase.phase_id)
+                record["phase_name"] = str(phase.name)
+                record["group_id"] = str(treatment.group.group_id)
+                record["group_name"] = str(treatment.group.name)
+                record["recommender_id"] = str(treatment.recommender.recommender_id)
+                record["recommender_name"] = str(treatment.recommender.name)
+                record["recommender_url"] = str(treatment.recommender.url)
+                records.append(record)
+
+        return records
+
 
 class S3AssignmentsRepository(S3Repository):
     def store_as_parquet(

--- a/src/poprox_storage/repositories/experiments.py
+++ b/src/poprox_storage/repositories/experiments.py
@@ -430,3 +430,26 @@ class S3ExperimentRepository(S3Repository):
     def fetch_manifest(self, manifest_file_key) -> ManifestFile:
         manifest_toml = self._get_s3_file(manifest_file_key)
         return parse_manifest_toml(manifest_toml)
+
+
+class S3AssignmentsRepository(S3Repository):
+    def store_as_parquet(
+        self,
+        assignments: list[Assignment],
+        bucket_name: str,
+        file_prefix: str,
+        start_time: datetime = None,
+    ) -> str:
+        records = self._extract_and_flatten(assignments)
+        return self._write_records_as_parquet(records, bucket_name, file_prefix, start_time)
+
+    def extract_and_flatten(self, assignments: list[Assignment]) -> list[dict]:
+        records = []
+        for assignment in assignments:
+            record = {}
+            record["profile_id"] = assignment.account_id
+            record["group_id"] = assignment.group_id
+            record["opted_out"] = assignment.opted_out
+            records.append(record)
+
+        return records

--- a/src/poprox_storage/repositories/experiments.py
+++ b/src/poprox_storage/repositories/experiments.py
@@ -285,7 +285,7 @@ class DbExperimentRepository(DatabaseRepository):
 
     def fetch_assignments_by_experiment_id(self, experiment_id: UUID) -> dict[UUID, Assignment]:
         experiment = self.fetch_experiment_by_id(experiment_id)
-        group_ids = [group.id for group in experiment.groups]
+        group_ids = [group.group_id for group in experiment.groups]
         group_lookup_by_account = self._fetch_assignments_by_group_ids(group_ids)
 
         return group_lookup_by_account

--- a/src/poprox_storage/repositories/experiments.py
+++ b/src/poprox_storage/repositories/experiments.py
@@ -443,13 +443,13 @@ class S3AssignmentsRepository(S3Repository):
         records = self._extract_and_flatten(assignments)
         return self._write_records_as_parquet(records, bucket_name, file_prefix, start_time)
 
-    def extract_and_flatten(self, assignments: list[Assignment]) -> list[dict]:
+    def _extract_and_flatten(self, assignments: list[Assignment]) -> list[dict]:
         records = []
         for assignment in assignments:
             record = {}
-            record["profile_id"] = assignment.account_id
-            record["group_id"] = assignment.group_id
-            record["opted_out"] = assignment.opted_out
+            record["profile_id"] = str(assignment.account_id)
+            record["group_id"] = str(assignment.group_id)
+            record["opted_out"] = int(assignment.opted_out or False)
             records.append(record)
 
         return records

--- a/src/poprox_storage/repositories/newsletters.py
+++ b/src/poprox_storage/repositories/newsletters.py
@@ -280,12 +280,13 @@ class S3NewsletterRepository(S3Repository):
         bucket_name: str,
         file_prefix: str,
         start_time: datetime = None,
+        include_treatment: bool = False,
     ) -> str:
-        records = extract_and_flatten(newsletters)
+        records = extract_and_flatten(newsletters, include_treatment=include_treatment)
         return self._write_records_as_parquet(records, bucket_name, file_prefix, start_time)
 
 
-def extract_and_flatten(newsletters: list[Newsletter]) -> list[dict]:
+def extract_and_flatten(newsletters: list[Newsletter], include_treatment: bool = False) -> list[dict]:
     impression_records = []
     for newsletter in newsletters:
         records = []
@@ -298,6 +299,8 @@ def extract_and_flatten(newsletters: list[Newsletter]) -> list[dict]:
             record["created_at"] = newsletter.created_at
             record["headline"] = impression.headline
             record["subhead"] = impression.subhead
+            if include_treatment:
+                record["treatment_id"] = str(newsletter.treatment_id)
             if impression.extra:
                 for k, v in impression.extra.items():
                     record[str(k)] = v

--- a/src/poprox_storage/repositories/newsletters.py
+++ b/src/poprox_storage/repositories/newsletters.py
@@ -299,6 +299,9 @@ def extract_and_flatten(newsletters: list[Newsletter], include_treatment: bool =
             record["created_at"] = newsletter.created_at
             record["headline"] = impression.headline
             record["subhead"] = impression.subhead
+            record["recommender_name"] = newsletter.recommender_info.name
+            record["recommender_version"] = newsletter.recommender_info.version
+            record["recommender_hash"] = newsletter.recommender_info.hash
             if include_treatment:
                 record["treatment_id"] = str(newsletter.treatment_id)
             if impression.extra:


### PR DESCRIPTION
Minor changes here include:
* Organizing clicks fetched by newsletter ids into per-user lists
* Adding a method to fetch clean survey responses between specific dates