### PR TITLE
add a class and function for fetching metrics that have been set up in cloudwatch

### DIFF
--- a/src/poprox_storage/aws/cloudwatch.py
+++ b/src/poprox_storage/aws/cloudwatch.py
@@ -1,0 +1,99 @@
+from collections import defaultdict
+from datetime import datetime
+from typing import List
+
+import boto3
+from botocore import exceptions
+
+from poprox_storage.aws.exceptions import PoproxAwsUtilitiesException
+
+
+class Cloudwatch:
+    def __init__(self, session: boto3.Session):
+        self.__session = session
+        self.cloudwatch_client = self.__session.client("cloudwatch")
+
+    def list_metrics(self, namespace):
+        response = self.cloudwatch_client.list_metrics(
+            Namespace=namespace,
+        )
+        return response
+
+    def get_metric_daily_count(
+        self, namespace: str, metrics: str | List[str], start_time: datetime, end_time: datetime
+    ) -> dict[datetime, dict[str, int]]:
+        """Gets values of metrics. FOR NOW this function only computes daily counts return value is a dictionary from
+        datetime objects to dicitonaries of metric values for that day, if a day has no metric values it will not be
+        returned"""
+        if isinstance(metrics, str):  # if they enter one metric treat it as a list
+            metrics = [metrics]
+
+        # TODO: timezones...
+
+        # clamp to date (since we're doing daily counts anyways)
+        start_time = start_time.replace(hour=0, minute=0, second=0, microsecond=0)
+        end_time = end_time.replace(hour=0, minute=0, second=0, microsecond=0)
+
+        metric_ids = {"m" + str(i): metric for i, metric in enumerate(metrics)}
+
+        metric_queries = [
+            {
+                "Id": metric_id,
+                "MetricStat": {
+                    "Metric": {
+                        "Namespace": namespace,
+                        "MetricName": metric,
+                        "Dimensions": [],  # this works for the custom onboarding metrics at least.
+                    },
+                    "Period": 60 * 60 * 24,  # daily
+                    "Stat": "SampleCount",
+                },
+                "ReturnData": True,
+            }
+            for metric_id, metric in metric_ids.items()
+        ]
+
+        data_results = []
+        next_token = None
+        while True:
+            try:
+                if next_token is not None:
+                    response = self.cloudwatch_client.get_metric_data(
+                        MetricDataQueries=metric_queries,
+                        StartTime=start_time,
+                        EndTime=end_time,
+                        ScanBy="TimestampAscending",
+                        NextToken=next_token,
+                    )
+                else:
+                    response = self.cloudwatch_client.get_metric_data(
+                        MetricDataQueries=metric_queries,
+                        StartTime=start_time,
+                        EndTime=end_time,
+                        ScanBy="TimestampAscending",
+                    )
+            except exceptions.ClientError as e:
+                msg = f"Error getting metric values for metrics {metrics}: {e}"
+                raise PoproxAwsUtilitiesException(msg) from e
+            data_results.extend(response.get("MetricDataResults", []))
+            next_token = response.get("NextToken")
+            if next_token is None:
+                # I wish python had do-while loops.
+                break
+        results = defaultdict(dict)
+        for data_result in data_results:
+            metric_name = metric_ids[data_result.get("Id")]
+            dates = data_result.get("Timestamps", [])
+            values = data_result.get("Values", [])
+            num = min(len(dates), len(values))
+            for i in range(num):
+                date = dates[i]
+                val = values[i]
+                results[date][metric_name] = val
+
+        # fill in with defaults
+        for result in results.values():
+            for metric in metrics:
+                if metric not in result:
+                    result[metric] = 0
+        return results


### PR DESCRIPTION
I'm seeing this as "step 1" towards `STORY: Platform operators can see completion rates on all onboarding steps`

Code has been tested locally using a `if __name__ == "__main__"` which I kind of wanted to keep but ultimately thought better of.

Useful reference if you intend to do a deep-dive review:
https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/cloudwatch/client/get_metric_data.html

but at a high-level the function takes one or more metrics and returns results on those metrics over a range of dates, example:
```
get_metric_daily_count(
                    "poprox-web/onboarding",
                    ["enroll page hits", "enroll form submission", "enroll email click"],
                    datetime(2025, 4, 1),
                    datetime(2025, 5, 21),
                )
```

Returns

```
{
  "2025-05-08 00:00:00+00:00": {
    "enroll page hits": 9,
    "enroll form submission": 2,
    "enroll email click": 3
  },
  "2025-05-09 00:00:00+00:00": {
    "enroll page hits": 12,
    "enroll form submission": 0,
    "enroll email click": 0
  },
  "2025-05-10 00:00:00+00:00": {
    "enroll page hits": 14,
    "enroll form submission": 1,
    "enroll email click": 1
  },
  "2025-05-11 00:00:00+00:00": {
    "enroll page hits": 8,
    "enroll form submission": 0,
    "enroll email click": 0
  },
  "2025-05-12 00:00:00+00:00": {
    "enroll page hits": 7,
    "enroll form submission": 2,
    "enroll email click": 2
  },
  "2025-05-13 00:00:00+00:00": {
    "enroll page hits": 7,
    "enroll form submission": 0,
    "enroll email click": 0
  },
  "2025-05-14 00:00:00+00:00": {
    "enroll page hits": 9,
    "enroll form submission": 1,
    "enroll email click": 2
  },
  "2025-05-15 00:00:00+00:00": {
    "enroll page hits": 13,
    "enroll form submission": 2,
    "enroll email click": 2
  },
  "2025-05-16 00:00:00+00:00": {
    "enroll page hits": 6,
    "enroll form submission": 0,
    "enroll email click": 0
  },
  "2025-05-17 00:00:00+00:00": {
    "enroll page hits": 1,
    "enroll form submission": 0,
    "enroll email click": 0
  },
  "2025-05-18 00:00:00+00:00": {
    "enroll page hits": 5,
    "enroll form submission": 0,
    "enroll email click": 0
  },
  "2025-05-19 00:00:00+00:00": {
    "enroll page hits": 1,
    "enroll form submission": 0,
    "enroll email click": 0
  },
  "2025-05-20 00:00:00+00:00": {
    "enroll page hits": 4,
    "enroll form submission": 0,
    "enroll email click": 0
  }
}
```

Core unaddressed concerns:
 * Only works for count type metrics
 * We don't have a great process for making metrics non-manually
 * hardcodes "daily metric"
 * Code is not timezone aware, manual testing shows that we get UTC results.
 * code uses datetime objects but works in dates.

Before chasing most of these down I wanted a second opinion on if it's worth it. My gut says "no" mostly because we don't have specific usecases for these features right now anyways.
