### PR TITLE
Provide a foundation in the database for features that send multiple newsletters

### DIFF
--- a/poprox-db/migrations/versions/2025_06_07_0850-61310e29d84f_.py
+++ b/poprox-db/migrations/versions/2025_06_07_0850-61310e29d84f_.py
@@ -7,10 +7,6 @@ Create Date: 2025-06-07 08:50:57.239850
 """
 from typing import Sequence, Union
 
-from alembic import op
-import sqlalchemy as sa
-
-
 # revision identifiers, used by Alembic.
 revision: str = '61310e29d84f'
 down_revision: Union[str, None] = ('f79aeb521ebb', '1d20bc70fa6d')

--- a/poprox-db/migrations/versions/2025_06_07_0850-61310e29d84f_.py
+++ b/poprox-db/migrations/versions/2025_06_07_0850-61310e29d84f_.py
@@ -1,0 +1,26 @@
+"""empty message
+
+Revision ID: 61310e29d84f
+Revises: f79aeb521ebb, 1d20bc70fa6d
+Create Date: 2025-06-07 08:50:57.239850
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '61310e29d84f'
+down_revision: Union[str, None] = ('f79aeb521ebb', '1d20bc70fa6d')
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass

--- a/poprox-db/migrations/versions/2025_06_07_0853-53e035b208d0_generalize_the_recommenders_table.py
+++ b/poprox-db/migrations/versions/2025_06_07_0853-53e035b208d0_generalize_the_recommenders_table.py
@@ -1,0 +1,54 @@
+"""Generalize the recommenders table
+
+Revision ID: 53e035b208d0
+Revises: 61310e29d84f
+Create Date: 2025-06-07 08:53:32.337982
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = '53e035b208d0'
+down_revision: Union[str, None] = '61310e29d84f'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.rename_table("expt_recommenders", "recommenders")
+    op.add_column(
+        "recommenders",
+        sa.Column("template", sa.String, nullable=True),
+    )
+    op.add_column(
+        "recommenders",
+        sa.Column("team_id", sa.UUID, nullable=True),
+    )
+
+    op.create_foreign_key(
+        "fk_recommenders_team_id",
+        "recommenders",
+        "teams",
+        ["team_id"],
+        ["team_id"],
+    )
+
+    op.create_check_constraint("ch_recommenders_team_or_expt", "recommenders",
+                               sa.or_(
+                                   sa.sql.column("experiment_id") is not None,
+                                   sa.sql.column("team_id") is not None
+                                )
+                            )
+
+    op.alter_column("recommenders", "experiment_id", nullable=True)
+
+def downgrade() -> None:
+    op.alter_column("recommenders", "experiment_id", nullable=False)
+    op.drop_constraint("ch_recommenders_team_or_expt", "recommenders")
+    op.drop_constraint("fk_recommenders_team_id", "recommenders", type_="foreignkey")
+    op.drop_column("recommenders", "team_id")
+    op.drop_column("recommenders", "template")
+    op.rename_table("recommenders", "expt_recommenders")

--- a/poprox-db/migrations/versions/2025_06_07_0854-87aa4d7933b2_create_an_experiences_table.py
+++ b/poprox-db/migrations/versions/2025_06_07_0854-87aa4d7933b2_create_an_experiences_table.py
@@ -1,0 +1,52 @@
+"""Create an experiences table
+
+Revision ID: 87aa4d7933b2
+Revises: 53e035b208d0
+Create Date: 2025-06-07 08:54:46.636431
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = '87aa4d7933b2'
+down_revision: Union[str, None] = '53e035b208d0'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "experiences",
+        sa.Column("experience_id", sa.UUID, primary_key=True, nullable=False),
+        sa.Column("recommender_id", sa.UUID, nullable=False),
+        sa.Column("team_id", sa.UUID, nullable=True),
+        sa.Column("name", sa.String, nullable=False),
+        sa.Column("start_date", sa.Date, nullable=False),
+        sa.Column("end_date", sa.Date, nullable=True),
+        sa.Column("created_at", sa.DateTime, nullable=False, server_default=sa.text("NOW()")),
+    )
+
+    op.create_foreign_key(
+        "fk_experiences_recommender_id",
+        "experiences",
+        "recommenders",
+        ["recommender_id"],
+        ["recommender_id"],
+    )
+    op.create_foreign_key(
+        "fk_top_stories_team_id",
+        "experiences",
+        "teams",
+        ["team_id"],
+        ["team_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("fk_top_stories_team_id", "top_stories", type_="foreignkey")
+    op.drop_constraint("fk_experiences_recommender_id", "top_stories", type_="foreignkey")
+
+    op.drop_table("experiences")

--- a/poprox-db/migrations/versions/2025_06_07_0901-151edfaa96af_link_newsletters_to_experiences.py
+++ b/poprox-db/migrations/versions/2025_06_07_0901-151edfaa96af_link_newsletters_to_experiences.py
@@ -1,0 +1,37 @@
+"""Link newsletters to experiences
+
+Revision ID: 151edfaa96af
+Revises: 87aa4d7933b2
+Create Date: 2025-06-07 09:01:25.346787
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = '151edfaa96af'
+down_revision: Union[str, None] = '87aa4d7933b2'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "newsletters",
+        sa.Column("experience_id", sa.UUID, nullable=True),
+    )
+
+    op.create_foreign_key(
+        "fk_newsletters_experience_id",
+        "newsletters",
+        "experiences",
+        ["experience_id"],
+        ["experience_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("fk_newsletters_experience_id", "newsletters", type_="foreignkey")
+    op.drop_column("newsletters", "experience_id")

--- a/src/poprox_storage/repositories/experiments.py
+++ b/src/poprox_storage/repositories/experiments.py
@@ -28,8 +28,8 @@ class DbExperimentRepository(DatabaseRepository):
             "expt_assignments",
             "expt_groups",
             "expt_phases",
-            "expt_recommenders",
             "expt_treatments",
+            "recommenders",
             "teams",
             "team_memberships",
         )
@@ -110,7 +110,7 @@ class DbExperimentRepository(DatabaseRepository):
 
     def fetch_experiment_phases(self, experiment_id: UUID) -> list[Phase]:
         treatment_table = self.tables["expt_treatments"]
-        recommenders_table = self.tables["expt_recommenders"]
+        recommenders_table = self.tables["recommenders"]
         phases_table = self.tables["expt_phases"]
 
         recommenders = self.fetch_experient_recommenders(experiment_id)
@@ -184,7 +184,7 @@ class DbExperimentRepository(DatabaseRepository):
         """Fetches all Recommender objects for an experiment.
         Returned dictionary maps recommender_id to recommender object."""
 
-        recommenders_table = self.tables["expt_recommenders"]
+        recommenders_table = self.tables["recommenders"]
 
         # get recommenders
         recommender_query = select(recommenders_table).where(recommenders_table.c.experiment_id == experiment_id)
@@ -218,7 +218,7 @@ class DbExperimentRepository(DatabaseRepository):
 
     def fetch_treatment_ids_by_experiment_id(self, experiment_id: UUID):
         treatments_tbl = self.tables["expt_treatments"]
-        recommenders_tbl = self.tables["expt_recommenders"]
+        recommenders_tbl = self.tables["recommenders"]
         query = (
             select(treatments_tbl.c.treatment_id)
             .join(
@@ -253,7 +253,7 @@ class DbExperimentRepository(DatabaseRepository):
         return treatment_lookup_by_group
 
     def fetch_treatment_recommender_urls(self, treatment_ids: list[UUID]) -> dict[UUID, str]:
-        recommenders_tbl = self.tables["expt_recommenders"]
+        recommenders_tbl = self.tables["recommenders"]
         treatments_tbl = self.tables["expt_treatments"]
 
         treatment_endpoint_query = (
@@ -273,7 +273,7 @@ class DbExperimentRepository(DatabaseRepository):
     def fetch_active_expt_recommender_urls(self, date: datetime.date | None = None) -> dict[UUID, str]:
         groups_tbl = self.tables["expt_groups"]
         phases_tbl = self.tables["expt_phases"]
-        recommenders_tbl = self.tables["expt_recommenders"]
+        recommenders_tbl = self.tables["recommenders"]
         treatments_tbl = self.tables["expt_treatments"]
 
         # Find the groups and associated recommenders for the active experiment phases
@@ -385,7 +385,7 @@ class DbExperimentRepository(DatabaseRepository):
         recommender: Recommender,
     ) -> UUID | None:
         return self._insert_model(
-            "expt_recommenders",
+            "recommenders",
             recommender,
             {
                 "recommender_name": recommender.name,

--- a/tests/repositories/test_experiments.py
+++ b/tests/repositories/test_experiments.py
@@ -33,7 +33,7 @@ def test_store_and_load_experiment():
             "expt_treatments",
             "expt_groups",
             "expt_phases",
-            "expt_recommenders",
+            "recommenders",
             "experiments",
             "datasets",
             "teams",


### PR DESCRIPTION
This makes schema changes we discussed on Friday to support multiple stories that involve sending additional newsletters to researchers and liaisons before and during experiments.

The schema we're aiming for looks like this, which generalizes the `recommenders` table, adds an `experiences` table, and connects newsletters to the experiences that generated them:

![gnome-shell-screenshot-dt5gd4](https://github.com/user-attachments/assets/ca2cd231-8f39-4a48-a594-0a1f374322a1)
