### PR TITLE
Make experiment start and end dates inclusive

### DIFF
--- a/src/poprox_storage/concepts/manifest.py
+++ b/src/poprox_storage/concepts/manifest.py
@@ -149,13 +149,13 @@ def convert_duration(duration: str) -> timedelta:
     quantity, unit = duration.split(" ")
     match unit:
         case unit if "week" in unit:
-            duration = timedelta(weeks=int(quantity))
+            delta = timedelta(weeks=int(quantity))
         case unit if "day" in unit:
-            duration = timedelta(days=int(quantity))
+            delta = timedelta(days=int(quantity))
         case _:
             msg = f"Unsupported duration unit: {unit}"
             raise ValueError(msg)
-    return duration
+    return delta
 
 
 def parse_manifest_toml(manifest_file: str):

--- a/src/poprox_storage/concepts/manifest.py
+++ b/src/poprox_storage/concepts/manifest.py
@@ -93,7 +93,8 @@ def manifest_to_experiment(manifest: ManifestFile) -> Experiment:
     """
     # XXX: we probably should actually fix this later.
     start_date = manifest.experiment.start_date or (date.today() + timedelta(days=1))  # noqa: DTZ011
-    end_date = start_date + convert_duration(manifest.experiment.duration)
+    # Include start date in the total duration
+    end_date = start_date - timedelta(days=1) + convert_duration(manifest.experiment.duration) 
 
     owner = Team(
         team_id=manifest.owner.team_id,

--- a/src/poprox_storage/repositories/accounts.py
+++ b/src/poprox_storage/repositories/accounts.py
@@ -150,15 +150,15 @@ class DbAccountRepository(DatabaseRepository):
         where_clause = or_(
             # Phase's start date is in the supplied range
             and_(
-                phase_tbl.c.start_date > start_date,
-                phase_tbl.c.start_date < end_date,
+                phase_tbl.c.start_date >= start_date,
+                phase_tbl.c.start_date <= end_date,
             ),
             # Phase's end date is in the supplied range
-            and_(phase_tbl.c.end_date > start_date, phase_tbl.c.end_date < end_date),
+            and_(phase_tbl.c.end_date >= start_date, phase_tbl.c.end_date <= end_date),
             # Phase's dates cover the whole supplied range
-            and_(phase_tbl.c.start_date < start_date, phase_tbl.c.end_date > end_date),
+            and_(phase_tbl.c.start_date <= start_date, phase_tbl.c.end_date >= end_date),
             # The supplied range covers the whole phase
-            and_(phase_tbl.c.start_date > start_date, phase_tbl.c.end_date < end_date),
+            and_(phase_tbl.c.start_date >= start_date, phase_tbl.c.end_date <= end_date),
         )
         phase_query = select(phase_tbl.c.phase_id).where(where_clause)
         phase_ids = self._id_query(phase_query)

--- a/src/poprox_storage/repositories/experiments.py
+++ b/src/poprox_storage/repositories/experiments.py
@@ -211,7 +211,7 @@ class DbExperimentRepository(DatabaseRepository):
         ).where(
             and_(
                 phases_tbl.c.start_date <= date,
-                date < phases_tbl.c.end_date,
+                date <= phases_tbl.c.end_date,
             )
         )
 
@@ -244,7 +244,7 @@ class DbExperimentRepository(DatabaseRepository):
         ).where(
             and_(
                 phases_tbl.c.start_date <= date,
-                date < phases_tbl.c.end_date,
+                date <= phases_tbl.c.end_date,
             )
         )
 
@@ -316,7 +316,7 @@ class DbExperimentRepository(DatabaseRepository):
         ).where(
             and_(
                 phases_tbl.c.start_date <= date,
-                date < phases_tbl.c.end_date,
+                date <= phases_tbl.c.end_date,
             )
         )
 


### PR DESCRIPTION
This makes it easier to understand when the last newsletter for an experiment is going to go out: it goes out on the end date of the experiment, not the day before.