### PR TITLE
Return empty strings for recommend info field if not recorded

### DIFF
--- a/src/poprox_storage/repositories/newsletters.py
+++ b/src/poprox_storage/repositories/newsletters.py
@@ -366,8 +366,8 @@ def extract_and_flatten(newsletters: list[Newsletter], include_treatment: bool =
             record["headline"] = impression.headline
             record["subhead"] = impression.subhead
             record["recommender_name"] = newsletter.recommender_info.name if newsletter.recommender_info else ""
-            record["recommender_version"] = newsletter.recommender_info.version  if newsletter.recommender_info else ""
-            record["recommender_hash"] = newsletter.recommender_info.hash  if newsletter.recommender_info else ""
+            record["recommender_version"] = newsletter.recommender_info.version if newsletter.recommender_info else ""
+            record["recommender_hash"] = newsletter.recommender_info.hash if newsletter.recommender_info else ""
             if include_treatment:
                 record["treatment_id"] = str(newsletter.treatment_id)
             if impression.extra:

--- a/src/poprox_storage/repositories/newsletters.py
+++ b/src/poprox_storage/repositories/newsletters.py
@@ -365,9 +365,9 @@ def extract_and_flatten(newsletters: list[Newsletter], include_treatment: bool =
             record["created_at"] = newsletter.created_at
             record["headline"] = impression.headline
             record["subhead"] = impression.subhead
-            record["recommender_name"] = newsletter.recommender_info.name
-            record["recommender_version"] = newsletter.recommender_info.version
-            record["recommender_hash"] = newsletter.recommender_info.hash
+            record["recommender_name"] = newsletter.recommender_info.name if newsletter.recommender_info else ""
+            record["recommender_version"] = newsletter.recommender_info.version  if newsletter.recommender_info else ""
+            record["recommender_hash"] = newsletter.recommender_info.hash  if newsletter.recommender_info else ""
             if include_treatment:
                 record["treatment_id"] = str(newsletter.treatment_id)
             if impression.extra:


### PR DESCRIPTION
This part of the record creation for the export fails with an error if `newsletter.recommender_info` is `None`. It _shouldn't_ be `None`, but if it is we should fail gracefully instead of preventing the export from running at all.