### PR TITLE
Exclude `newsletter_html` from survey response keys when cleaning

### DIFF
--- a/src/poprox_storage/concepts/qualtrics_survey.py
+++ b/src/poprox_storage/concepts/qualtrics_survey.py
@@ -52,7 +52,7 @@ class QualtricsCleanResponse(BaseModel):
             "status",
             "distributionChannel",
             "survey_instance_id",
-            "newsletter_html"
+            "newsletter_html",
         ]
 
         for denied_key in deny_list:


### PR DESCRIPTION
Let's try adding it to the pre-existing deny list and see if that's enough.