### PR TITLE
fix(newsletters): safely handle missing 'extra' column in _convert_to_impression_obj

### DIFF
--- a/src/poprox_storage/repositories/newsletters.py
+++ b/src/poprox_storage/repositories/newsletters.py
@@ -275,7 +275,7 @@ class DbNewsletterRepository(DatabaseRepository):
             headline=row.headline,
             subhead=row.subhead,
             position=row.position,
-            extra=row.extra,
+            extra=getattr(row, "extra", None),
             feedback=row.feedback,
             article=Article(
                 article_id=row.articles_article_id,


### PR DESCRIPTION
Replaced direct access to `row.extra` with `getattr(row, "extra", None)` 
to prevent crashes when the 'extra' column is absent in impressions query result.