### PR TITLE
Allow accounts to be updated at the model level.

### DIFF
--- a/src/poprox_storage/repositories/accounts.py
+++ b/src/poprox_storage/repositories/accounts.py
@@ -72,20 +72,22 @@ class DbAccountRepository(DatabaseRepository):
             return accounts[0]
         return None
 
-    def store_account(self, account: Account) -> UUID | None:
+    def store_account(self, account: Account, commit=True) -> UUID | None:
         account_tbl = self.tables["accounts"]
-        query = (
-            sqlalchemy.insert(account_tbl)
-            .values(
-                account_id=account.account_id,
-                email=account.email,
-                source=account.source,
-                status="new_account",
-            )
-            .returning(account_tbl.c.account_id)
+        return self._upsert_and_return_id(
+            self.conn,
+            account_tbl,
+            {
+                "account_id": account.account_id,
+                "email": account.email,
+                "source": account.source,
+                "subsource": account.subsource,
+                "status": account.status,
+            },
+            # NOTE -- this is not explicitly named in out migrations and therefore is _fragile_
+            constraint="account_pkey",
+            commit=commit,  # do not commit so we throw errors.
         )
-        row = self.conn.execute(query).one_or_none()
-        return row.account_id
 
     def store_new_account(self, email: str, source: str, subsource: str = None) -> Account:
         account_tbl = self.tables["accounts"]

--- a/src/poprox_storage/repositories/accounts.py
+++ b/src/poprox_storage/repositories/accounts.py
@@ -72,7 +72,7 @@ class DbAccountRepository(DatabaseRepository):
             return accounts[0]
         return None
 
-    def store_account(self, account: Account, commit=True) -> UUID | None:
+    def store_account(self, account: Account, commit=False) -> UUID | None:
         account_tbl = self.tables["accounts"]
         return self._upsert_and_return_id(
             self.conn,
@@ -86,7 +86,7 @@ class DbAccountRepository(DatabaseRepository):
             },
             # NOTE -- this is not explicitly named in out migrations and therefore is _fragile_
             constraint="account_pkey",
-            commit=commit,  # do not commit so we throw errors.
+            commit=commit,
         )
 
     def store_new_account(self, email: str, source: str, subsource: str = None) -> Account:

--- a/src/poprox_storage/repositories/accounts.py
+++ b/src/poprox_storage/repositories/accounts.py
@@ -56,26 +56,18 @@ class DbAccountRepository(DatabaseRepository):
 
         return self._fetch_acounts(query)
 
-    def fetch_account_by_email(self, email: str) -> Account | None:
+    def fetch_account_by_email_query(self, email_query: str) -> list[Account]:
         account_tbl = self.tables["accounts"]
         query = sqlalchemy.select(
-            account_tbl.c.account_id,
-            account_tbl.c.email,
-            account_tbl.c.status,
-            account_tbl.c.source,
-            account_tbl.c.created_at,
-        ).where(account_tbl.c.email == email)
-        result = self.conn.execute(query).fetchall()
-        accounts = [
-            Account(
-                account_id=row.account_id,
-                email=row.email,
-                status=row.status,
-                source=row.source,
-                created_at=row.created_at,
-            )
-            for row in result
-        ]
+            account_tbl,
+        ).where(account_tbl.c.email.like(email_query))
+        return self._fetch_acounts(query)
+
+    def fetch_account_by_email(self, email: str) -> Account | None:
+        account_tbl = self.tables["accounts"]
+        query = sqlalchemy.select(account_tbl).where(account_tbl.c.email == email)
+        accounts = self._fetch_acounts(query)
+
         if len(accounts) > 0:
             return accounts[0]
         return None


### PR DESCRIPTION
forked off of CCRI-POPROX/poprox-storage#134 but not doing the same thing. Only change local to this is the store_account change. 

change store_account function to be an upsert instead of direct insert, this suitably matches all current uses, and de-duplicates this from the new-account function below it.

I only made fields we might _want_ to update update, rather than all fields at once. I forwarded the `commit` property from the upsert function to allow web to say "no" and get it's exceptions for admin feedback purposes.