### PR TITLE
make experiences with null end date count as active

### DIFF
--- a/src/poprox_storage/repositories/experience.py
+++ b/src/poprox_storage/repositories/experience.py
@@ -1,7 +1,7 @@
 from datetime import date
 from uuid import UUID
 
-from sqlalchemy import Connection, Table, and_, select
+from sqlalchemy import Connection, Table, and_, or_, select
 
 from poprox_concepts.domain.experience import Experience
 from poprox_storage.repositories.data_stores.db import DatabaseRepository
@@ -41,7 +41,7 @@ class DbExperiencesRepository(DatabaseRepository):
         query = select(experiences_table).where(
             and_(
                 experiences_table.c.start_date <= current_date,
-                experiences_table.c.end_date >= current_date,
+                or_(experiences_table.c.end_date >= current_date, experiences_table.c.end_date.is_(None)),
             )
         )
         results = self.conn.execute(query).fetchall()

--- a/tests/repositories/test_experiences.py
+++ b/tests/repositories/test_experiences.py
@@ -1,0 +1,66 @@
+import datetime
+from uuid import uuid4
+
+from sqlalchemy import insert
+
+from poprox_storage.concepts.experiment import Recommender, Team
+from poprox_storage.repositories.experience import DbExperiencesRepository
+from poprox_storage.repositories.experiments import DbExperimentRepository
+from poprox_storage.repositories.teams import DbTeamRepository
+from tests import clear_tables
+
+
+def test_non_ending_experience_is_active(db_engine):
+    with db_engine.connect() as conn:
+        clear_tables(
+            conn,
+            "experiences",
+            "expt_treatments",
+            "recommenders",
+            "team_memberships",
+            "clicks",
+            "account_aliases",
+            "accounts",
+            "expt_phases",
+            "expt_groups",
+            "experiments",
+            "datasets",
+            "teams",
+        )
+
+        experience_repo = DbExperiencesRepository(conn)
+        team_repo = DbTeamRepository(conn)
+        # rec_repo = DbRecommenderRepository(conn)
+        exp_repo = DbExperimentRepository(conn)
+        team = Team(team_id=uuid4(), team_name="test", members=[])
+        team_repo.store_team(team)
+
+        # FIXME -- create a general repo function for inserting team recommenders
+        rec = Recommender(recommender_id=uuid4(), name="test_rec", url="http://example.org")
+        insert_query = insert(exp_repo.tables["recommenders"]).values(
+            {
+                "recommender_id": rec.recommender_id,
+                "recommender_name": rec.name,
+                "endpoint_url": rec.url,
+                "team_id": team.team_id,
+            }
+        )
+        conn.execute(insert_query)
+
+        # FIXME -- create a function for making experiences
+        today = datetime.date.today()
+        experience_id = uuid4()
+        insert_query = insert(experience_repo.tables["experiences"]).values(
+            {
+                "experience_id": experience_id,
+                "recommender_id": rec.recommender_id,
+                "name": "test name",
+                "team_id": team.team_id,
+                "start_date": today,
+            }
+        )
+        conn.execute(insert_query)
+
+        results = experience_repo.fetch_active_experiences(today)
+
+        assert 1 == len(results)

--- a/tests/repositories/test_experiences.py
+++ b/tests/repositories/test_experiences.py
@@ -20,6 +20,7 @@ def test_non_ending_experience_is_active(db_engine):
             "team_memberships",
             "clicks",
             "account_aliases",
+            "newsletters",
             "accounts",
             "expt_phases",
             "expt_groups",


### PR DESCRIPTION
Code is _explicitly_ tested with a pytest and everything. so I'm not worried about it being wrong. @karlhigley -- I'm looking for a second opinion on whether the `#fixme`'s in the test files are worth blocking for.

My gut says "no don't block -- let's merge now and write these missing functions later". but It feels a bit dirty and I want someone else's opinion.The upside of doing this is that this bug is blocking experiences from auto-sending right now

