### PR TITLE
Raise error if a non-internal account is added to a team

### DIFF
--- a/src/poprox_storage/repositories/teams.py
+++ b/src/poprox_storage/repositories/teams.py
@@ -2,7 +2,7 @@ from uuid import UUID
 
 from sqlalchemy import Connection, Table, select
 
-from poprox_concepts.domain.account import is_internal_account
+from poprox_concepts.domain.account import INTERNAL_ACCOUNT_SOURCES
 from poprox_storage.concepts.experiment import Recommender, Team
 from poprox_storage.repositories.data_stores.db import DatabaseRepository
 
@@ -64,7 +64,7 @@ class DbTeamRepository(DatabaseRepository):
 
         account_query = select(accounts_tbl.c.source).where(accounts_tbl.c.account_id == account_id)
         account_source = self.conn.execute(account_query).scalar_one()
-        if is_internal_account(account_source):
+        if account_source in INTERNAL_ACCOUNT_SOURCES:
             return self._upsert_and_return_id(
                 self.conn,
                 self.tables["team_memberships"],


### PR DESCRIPTION
Considerations:

- Do we want a more specific error type here? If so, what? Do we have a PoproxError already? (I couldn't find one, but I could've missed it)
 - From what I can tell this is used in three clear places:
     1. Manual Ingress lambda for an experiment
     2. Admin Team membership interface
     3. Experimenter Team management interface
 - I would guess that 2. and 3. should be checked for decent error messages, but what about 1. Are we happy just letting this "fail fast?"