### PR TITLE
make fetch_article_by_external_id source-aware

### DIFF
--- a/poprox-db/migrations/versions/2026_07_06_1830-62b01cd7d748_add_source_external_id_index_to_articles.py
+++ b/poprox-db/migrations/versions/2026_07_06_1830-62b01cd7d748_add_source_external_id_index_to_articles.py
@@ -1,0 +1,30 @@
+"""add source external_id index to articles
+
+Adds a non-unique index on articles(source, external_id) to back the source-aware
+lookup added to DbArticleRepository.fetch_article_by_external_id. The pair is
+intentionally NOT unique: multiple rows per (source, external_id) are expected --
+they are kept as history and deduped to the latest row at read time.
+
+Revision ID: 62b01cd7d748
+Revises: d4e5f6a7b8c9
+Create Date: 2026-07-06 18:30:32.656756
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "62b01cd7d748"
+down_revision: Union[str, None] = "d4e5f6a7b8c9"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_index("ix_articles_source_external_id", "articles", ["source", "external_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_articles_source_external_id", table_name="articles")

--- a/src/poprox_storage/repositories/articles.py
+++ b/src/poprox_storage/repositories/articles.py
@@ -179,9 +179,12 @@ class DbArticleRepository(DatabaseRepository):
 
         return list(package_lookup.values())
 
-    def fetch_article_by_external_id(self, id_: str) -> Article | None:
+    def fetch_article_by_external_id(self, id_: str, source: str | None = None) -> Article | None:
         article_table = self.tables["articles"]
-        deduped = self._get_deduped_articles(article_table, article_table.c.external_id == id_)
+        where_clause = article_table.c.external_id == id_
+        if source is not None:
+            where_clause = and_(where_clause, article_table.c.source == source)
+        deduped = self._get_deduped_articles(article_table, where_clause)
         return deduped[0] if deduped else None
 
     def fetch_article_mentions(self, articles: list[Article]) -> list[Article]:

--- a/tests/repositories/test_articles.py
+++ b/tests/repositories/test_articles.py
@@ -1,0 +1,141 @@
+from datetime import datetime
+
+from sqlalchemy import text
+
+from poprox_concepts.domain import Article
+from poprox_storage.repositories.articles import DbArticleRepository
+from tests import clear_tables
+
+# Article children first (leaf tables that reference articles), then the rest, then articles.
+_TABLES = [
+    "mentions",
+    "article_image_associations",
+    "article_links",
+    "candidate_articles",
+    "impressions",
+    "clicks",
+    "impressed_sections",
+    "section_types",
+    "newsletters",
+    "article_placements",
+    "articles",
+]
+
+
+def test_fetch_by_external_id_is_source_aware(db_engine):
+    # Two sources sharing an external_id must stay distinguishable (the core fix).
+    with db_engine.connect() as conn:
+        clear_tables(conn, *_TABLES)
+        repo = DbArticleRepository(conn)
+        repo.store_article(
+            Article(headline="ap story", url="https://apnews.com/x", source="AP", external_id="shared-1")
+        )
+        repo.store_article(
+            Article(headline="pp story", url="https://propublica.org/x", source="ProPublica", external_id="shared-1")
+        )
+
+        ap = repo.fetch_article_by_external_id("shared-1", source="AP")
+        pp = repo.fetch_article_by_external_id("shared-1", source="ProPublica")
+
+        assert ap is not None
+        assert ap.source == "AP"
+        assert ap.headline == "ap story"
+        assert pp is not None
+        assert pp.source == "ProPublica"
+        assert pp.headline == "pp story"
+        # right id, wrong source -> nothing
+        assert repo.fetch_article_by_external_id("shared-1", source="Reuters") is None
+        # unknown id -> nothing
+        assert repo.fetch_article_by_external_id("does-not-exist", source="AP") is None
+
+
+def test_fetch_by_external_id_without_source_is_backward_compatible(db_engine):
+    # Omitting source keeps the pre-change behavior: returns a matching row (not None), source-blind.
+    with db_engine.connect() as conn:
+        clear_tables(conn, *_TABLES)
+        repo = DbArticleRepository(conn)
+        repo.store_article(
+            Article(headline="ap story", url="https://apnews.com/x", source="AP", external_id="shared-2")
+        )
+        repo.store_article(
+            Article(headline="pp story", url="https://propublica.org/x", source="ProPublica", external_id="shared-2")
+        )
+
+        result = repo.fetch_article_by_external_id("shared-2")
+        assert result is not None
+        assert result.external_id == "shared-2"
+
+
+def test_metadata_only_article_round_trips(db_engine):
+    # A ProPublica-shaped article: body text, canonical url, no images/mentions.
+    with db_engine.connect() as conn:
+        clear_tables(conn, *_TABLES)
+        repo = DbArticleRepository(conn)
+        repo.store_article(
+            Article(
+                headline="An Investigation",
+                url="https://www.propublica.org/article/investigation",
+                source="ProPublica",
+                external_id="pp-meta-1",
+                body="full article text",
+                images=None,
+                preview_image_id=None,
+            )
+        )
+
+        article = repo.fetch_article_by_external_id("pp-meta-1", source="ProPublica")
+        assert article is not None
+        assert article.headline == "An Investigation"
+        assert article.url == "https://www.propublica.org/article/investigation"
+        assert article.source == "ProPublica"
+        assert article.body == "full article text"
+        assert not article.images  # None/empty: no images persisted
+
+        # metadata-only -> zero image-association and mention rows
+        assert conn.execute(text("SELECT count(*) FROM article_image_associations")).scalar() == 0
+        assert conn.execute(text("SELECT count(*) FROM mentions")).scalar() == 0
+
+
+def test_same_source_external_id_dedups_to_latest(db_engine):
+    # Multiple rows per (source, external_id) are kept as history; fetch returns the newest.
+    with db_engine.connect() as conn:
+        clear_tables(conn, *_TABLES)
+        repo = DbArticleRepository(conn)
+        repo.store_article(
+            Article(
+                headline="v1 headline",
+                url="https://apnews.com/dup/v1",
+                source="AP",
+                external_id="dup-1",
+                created_at=datetime(2024, 1, 1),
+            )
+        )
+        repo.store_article(
+            Article(
+                headline="v2 headline",
+                url="https://apnews.com/dup/v2",
+                source="AP",
+                external_id="dup-1",
+                created_at=datetime(2025, 1, 1),
+            )
+        )
+
+        # both rows persisted (history kept, not overwritten)
+        count = conn.execute(
+            text("SELECT count(*) FROM articles WHERE source = 'AP' AND external_id = 'dup-1'")
+        ).scalar()
+        assert count == 2
+
+        latest = repo.fetch_article_by_external_id("dup-1", source="AP")
+        assert latest is not None
+        assert latest.headline == "v2 headline"  # newest created_at wins
+
+
+def test_null_url_is_rejected_by_schema(db_engine):
+    # url is NOT NULL: a url-less article is rejected -- the repo catches the NotNullViolation,
+    # logs it, and returns None, so it is never silently stored.
+    with db_engine.connect() as conn:
+        clear_tables(conn, *_TABLES)
+        repo = DbArticleRepository(conn)
+        result = repo.store_article(Article(headline="no url", url=None, source="AP", external_id="no-url-1"))
+        assert result is None

--- a/tests/repositories/test_articles.py
+++ b/tests/repositories/test_articles.py
@@ -67,7 +67,7 @@ def test_fetch_by_external_id_without_source_is_backward_compatible(db_engine):
 
 
 def test_metadata_only_article_round_trips(db_engine):
-    # A ProPublica-shaped article: body text, canonical url, no images/mentions.
+    # A ProPublica-shaped link-out article: canonical url, no full text, images, or mentions.
     with db_engine.connect() as conn:
         clear_tables(conn, *_TABLES)
         repo = DbArticleRepository(conn)
@@ -77,7 +77,7 @@ def test_metadata_only_article_round_trips(db_engine):
                 url="https://www.propublica.org/article/investigation",
                 source="ProPublica",
                 external_id="pp-meta-1",
-                body="full article text",
+                body=None,
                 images=None,
                 preview_image_id=None,
             )
@@ -88,7 +88,7 @@ def test_metadata_only_article_round_trips(db_engine):
         assert article.headline == "An Investigation"
         assert article.url == "https://www.propublica.org/article/investigation"
         assert article.source == "ProPublica"
-        assert article.body == "full article text"
+        assert article.body is None
         assert not article.images  # None/empty: no images persisted
 
         # metadata-only -> zero image-association and mention rows


### PR DESCRIPTION
Groundwork before ProPublica ingest (PROJ-1327). fetch_article_by_external_id only filtered on external_id, so once a second source writes rows with overlapping ids it could hand back the wrong source's article. this makes it source-aware via an optional arg (old callers unchanged) and adds a non-unique index on (source, external_id) for that lookup.

I didn't touch uq_articles or the write path: urls are source-specific (propublica.org vs apnews.com) so store_article already can't collide across sources, and (source, external_id) can legitimately repeat (kept as history, deduped to latest at read time) so a unique constraint would be wrong.

rebased onto current main and tested locally against a fresh dev db:
- [x] two sources sharing an external_id stay distinguishable; wrong-source / unknown-id -> None
- [x] omitting source keeps the old behavior (backward compatible)
- [x] metadata-only link-out article (body=None, no images/mentions) round-trips
- [x] same (source, external_id) keeps history, fetch returns the newest
- [x] full existing suite green; ruff + pre-commit clean; migration upgrade succeeds

one unrelated heads-up: the alembic stairstep test (poprox-db/test.sh, not in CI) has a pre-existing failure -- the create_article_packages_tables downgrade references "particle_ackage_contents" instead of "article_package_contents". not from this change, happy to fix separately if useful.
